### PR TITLE
npm scripts, dependencies and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # Phaser 3 Examples
 
-To show the example browser:
+### Requirements
 
-`npm install -g http-server`
+We need [Node.js](https://nodejs.org) to install and run scripts.
 
-`http-server -s -o`
 
-To build a new `examples.json` file if you add a new example:
+### Install and run
 
-`node build.js`
+To show the example browser run next commands in your terminal:
 
+| Command | Description |
+|---------|-------------|
+| `npm install` | Install dependencies and lunch browser with examples.|
+| `npm start` | Lunch browser to show the examples. <br> Press `Ctrl + c` to kill **http-server** process. |
+| `npm run update` | To build a new `examples.json` file if you add a new example. |

--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ To show the example browser run next commands in your terminal:
 
 | Command | Description |
 |---------|-------------|
-| `npm install` | Install dependencies and lunch browser with examples.|
-| `npm start` | Lunch browser to show the examples. <br> Press `Ctrl + c` to kill **http-server** process. |
+| `npm install` | Install dependencies and launch browser with examples.|
+| `npm start` | Launch browser to show the examples. <br> Press `Ctrl + c` to kill **http-server** process. |
 | `npm run update` | To build a new `examples.json` file if you add a new example. |

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Phaser 3 Examples",
   "main": "index.js",
   "scripts": {
+    "postinstall": "npm start",
+    "start": "./node_modules/.bin/http-server -s -o",
+    "update": "node ./build.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -18,9 +21,7 @@
   "homepage": "https://github.com/photonstorm/phaser3-examples#readme",
   "devDependencies": {
     "http-server": "^0.9.0",
-    "monaco-editor": "^0.8.0"
-  },
-  "dependencies": {
+    "monaco-editor": "^0.8.0",
     "directory-tree": "^1.2.0"
   }
 }


### PR DESCRIPTION
- Added npm scripts to run commands
- Moved to dependency `directory-tree` to devDependencies, we don't need  this to production
- Updated README with the new scripts and remove `npm install -g http-server`, we don't need install global package because we've into `devDependencies`