### PR TITLE
Fixed snake game errors

### DIFF
--- a/public/src/games/snake/part2.js
+++ b/public/src/games/snake/part2.js
@@ -124,7 +124,7 @@ function create ()
             this.direction = this.heading;
 
             //  Update the body segments
-            this.body.shiftPosition(this.headPosition.x * 16, this.headPosition.y * 16, 1);
+            Phaser.Actions.ShiftPosition(this.body.children.entries, this.headPosition.x * 16, this.headPosition.y * 16, 1);
 
             //  Update the timer ready for the next movement
             this.moveTime = time + this.speed;

--- a/public/src/games/snake/part3.js
+++ b/public/src/games/snake/part3.js
@@ -148,7 +148,7 @@ function create ()
             this.direction = this.heading;
 
             //  Update the body segments and place the last coordinate into this.tail
-            this.body.shiftPosition(this.headPosition.x * 16, this.headPosition.y * 16, 1, this.tail);
+            Phaser.Actions.ShiftPosition(this.body.children.entries, this.headPosition.x * 16, this.headPosition.y * 16, 1, this.tail);
 
             //  Update the timer ready for the next movement
             this.moveTime = time + this.speed;

--- a/public/src/games/snake/part4.js
+++ b/public/src/games/snake/part4.js
@@ -158,7 +158,7 @@ function create ()
             this.direction = this.heading;
 
             //  Update the body segments and place the last coordinate into this.tail
-            this.body.shiftPosition(this.headPosition.x * 16, this.headPosition.y * 16, 1, this.tail);
+            Phaser.Actions.ShiftPosition(this.body.children.entries, this.headPosition.x * 16, this.headPosition.y * 16, 1, this.tail);
 
             //  Update the timer ready for the next movement
             this.moveTime = time + this.speed;

--- a/public/src/games/snake/part5.js
+++ b/public/src/games/snake/part5.js
@@ -158,7 +158,7 @@ function create ()
             this.direction = this.heading;
 
             //  Update the body segments and place the last coordinate into this.tail
-            this.body.shiftPosition(this.headPosition.x * 16, this.headPosition.y * 16, 1, this.tail);
+            Phaser.Actions.ShiftPosition(this.body.children.entries, this.headPosition.x * 16, this.headPosition.y * 16, 1, this.tail);
 
             //  Update the timer ready for the next movement
             this.moveTime = time + this.speed;

--- a/public/src/games/snake/part6.js
+++ b/public/src/games/snake/part6.js
@@ -153,7 +153,7 @@ function create ()
             this.direction = this.heading;
 
             //  Update the body segments and place the last coordinate into this.tail
-            this.body.shiftPosition(this.headPosition.x * 16, this.headPosition.y * 16, 1, this.tail);
+            Phaser.Actions.ShiftPosition(this.body.children.entries, this.headPosition.x * 16, this.headPosition.y * 16, 1, this.tail);
 
             //  Update the timer ready for the next movement
             this.moveTime = time + this.speed;

--- a/public/src/games/snake/part7.js
+++ b/public/src/games/snake/part7.js
@@ -153,12 +153,12 @@ function create ()
             this.direction = this.heading;
 
             //  Update the body segments and place the last coordinate into this.tail
-            this.body.shiftPosition(this.headPosition.x * 16, this.headPosition.y * 16, 1, this.tail);
+            Phaser.Actions.ShiftPosition(this.body.children.entries, this.headPosition.x * 16, this.headPosition.y * 16, 1, this.tail);
 
             //  Check to see if any of the body pieces have the same x/y as the head
             //  If they do, the head ran into the body
 
-            var hitBody = this.body.getFirst({ x: this.head.x, y: this.head.y }, 1);
+            var hitBody = Phaser.Actions.GetFirst(this.body.children.entries, { x: this.head.x, y: this.head.y }, 1);
 
             if (hitBody)
             {

--- a/public/src/games/snake/part8.js
+++ b/public/src/games/snake/part8.js
@@ -176,12 +176,12 @@ function create ()
             this.direction = this.heading;
 
             //  Update the body segments and place the last coordinate into this.tail
-            this.body.shiftPosition(this.headPosition.x * 16, this.headPosition.y * 16, 1, this.tail);
+            Phaser.Actions.ShiftPosition(this.body.children.entries, this.headPosition.x * 16, this.headPosition.y * 16, 1, this.tail);
 
             //  Check to see if any of the body pieces have the same x/y as the head
             //  If they do, the head ran into the body
 
-            var hitBody = this.body.getFirst({ x: this.head.x, y: this.head.y }, 1);
+            var hitBody = Phaser.Actions.GetFirst(this.body.children.entries, { x: this.head.x, y: this.head.y }, 1);
 
             if (hitBody)
             {


### PR DESCRIPTION
Since shiftPosition function is moved out of Group class part2 to part8 examples in snake game was failing. Calling Phaser.Actions.ShiftPosition to fix the error.