### PR TITLE
Fixed input handling for "Multiple Physics Scenes" MatterJS example

### DIFF
--- a/public/src/physics/matterjs/multiple physics scenes.js
+++ b/public/src/physics/matterjs/multiple physics scenes.js
@@ -26,11 +26,11 @@ var SceneA = new Phaser.Class({
             ball.setBounce(1);
         }
 
-        this.input.once('POINTER_DOWN_EVENT', function (event) {
+        this.input.once('pointerdown', function (event) {
 
             this.scene.start('sceneB');
 
-        }, 0, this);
+        }, this);
     }
 
 });
@@ -63,11 +63,11 @@ var SceneB = new Phaser.Class({
             ball.setBounce(1);
         }
 
-        this.input.once('POINTER_DOWN_EVENT', function (event) {
+        this.input.once('pointerdown', function (event) {
 
             this.scene.start('sceneA');
 
-        }, 0, this);
+        }, this);
     }
 
 });


### PR DESCRIPTION
This PR just fixes the input handling in this example. It was broken since the changes to the event names and, I think, the signature of the event methods.

I tested this locally, the change makes the example work as expected.

Cheers!