### PR TITLE
RenderTexture examples, Camera Example, Textures Examples. 

### DIFF
--- a/public/src/camera/background color interpolate.js
+++ b/public/src/camera/background color interpolate.js
@@ -1,0 +1,55 @@
+var config = {
+    type: Phaser.AUTO,
+    parent: 'phaser-example',
+    scene: {
+        preload: preload,
+        create: create,
+        update: update
+    },
+    width: 800,
+    height: 600
+};
+
+var game = new Phaser.Game(config);
+
+var player;
+
+var sky;
+var space;
+
+var w;
+var h;
+
+function preload()
+{
+    this.load.image('star', 'assets/demoscene/star2.png');
+    this.load.image('dude', 'assets/sprites/phaser-dude.png');
+}
+
+function create()
+{
+    w = this.cameras.main.width;
+    h = this.cameras.main.height;
+    
+    bg = this.add.group({ key: 'star', frameQuantity: 300 });
+
+    sky = new Phaser.Display.Color(120, 120, 255);
+    space = new Phaser.Display.Color(0, 0, 0);
+
+    player = this.add.sprite(w / 2, 0, 'dude');
+
+    this.cameras.main.startFollow(player);
+
+    var rect = new Phaser.Geom.Rectangle(0, -2 * h, w, 2 * h);
+
+    Phaser.Actions.RandomRectangle(bg.getChildren(), rect);
+}
+
+function update()
+{
+    player.y = (Math.cos(this.time.now / 1000) * (h - 10)) - h;
+
+    var hexColor = Phaser.Display.Color.Interpolate.ColorWithColor(sky, space, -h * 2, player.y);
+
+    this.cameras.main.setBackgroundColor(hexColor);
+}

--- a/public/src/camera/ignore.js
+++ b/public/src/camera/ignore.js
@@ -1,5 +1,5 @@
 var config = {
-    type: Phaser.CANVAS,
+    type: Phaser.AUTO,
     parent: 'phaser-example',
     scene: {
         preload: preload,
@@ -20,36 +20,30 @@ var ui_text3;
 
 function preload() 
 {
-    this.load.baseURL = '//examples.phaser.io/';
-    this.load.crossOrigin = 'anonymous';
-    this.load.image('einstein', 'assets/pics/ra_einstein.png');
+    this.load.image('einstein', 'assets/pics/ra-einstein.png');
 }
 
 function create() 
 {
-
     image = this.add.image(400, 300, 'einstein');
 
-    ui_text1 = this.add.text(400,50,"0");
-    ui_text2 = this.add.text(400,100,"0");
-    ui_text3 = this.add.text(400,150,"0");
-    
+    ui_text1 = this.add.text(400, 50, "0");
+    ui_text2 = this.add.text(400, 100, "0");
+    ui_text3 = this.add.text(400, 150, "0");
+
     ui_camera = this.cameras.add(0, 0, 800, 600);
-    
-    this.cameras.main.ignore([ui_text1,ui_text2,ui_text3]);
+
+    this.cameras.main.ignore([ui_text1, ui_text2, ui_text3]);
     ui_camera.ignore(image);
-    
 }
 
-function update()
+function update() 
 {
+    ui_text1.setText("main camera rotation: " + this.cameras.main.rotation);
+    ui_text2.setText("main camera zoom: " + this.cameras.main.zoom);
+    ui_text3.setText("main camera shake X: " + this.cameras.main._shakeOffsetX);
 
-    ui_text1.setText("main camera rotation: "+this.cameras.main.rotation);
-    ui_text2.setText("main camera zoom: "+this.cameras.main.zoom);
-    ui_text3.setText("main camera shake X: "+this.cameras.main._shakeOffsetX);
-    
-    this.cameras.main.setZoom(Math.abs(Math.sin(this.cameras.main.rotation))*0.5 +1);
-    this.cameras.main.rotation +=0.01;
-    this.cameras.main.shake(500,0.001);
-    
+    this.cameras.main.setZoom(Math.abs(Math.sin(this.cameras.main.rotation)) * 0.5 + 1);
+    this.cameras.main.rotation += 0.01;
+    this.cameras.main.shake(500, 0.001);
 }

--- a/public/src/game objects/render texture/brute force.js
+++ b/public/src/game objects/render texture/brute force.js
@@ -1,0 +1,61 @@
+var config = {
+    type: Phaser.AUTO,
+    parent: 'phaser-example',
+    scene: {
+        preload: preload,
+        create: create,
+        update: update
+    },
+    width: 800,
+    height: 600
+};
+
+var game = new Phaser.Game(config);
+
+var rt;
+var matrixTexture;
+var t;
+
+function preload()
+{
+    this.load.baseURL = "https://cdn.rawgit.com/samid737/samid737.github.io/eca38c92/409/";
+    this.load.crossOrigin = 'anonymous';
+    this.load.spritesheet('matrix', '/assets/sprites/font.png', { frameWidth: 110, frameHeight: 125, endFrame: 23 });
+}
+
+function create()
+{
+    matrixTexture = this.textures.get('matrix');
+
+    rt = this.make.renderTexture({ x: 0, y: 0, width: 800, height: 600 }).setOrigin(0, 0);
+}
+
+function update()
+{
+    for (i = 0; i < 20; i++)
+    {
+        draw();
+    }
+
+    t = this.time.now / 100000;
+
+    this.cameras.main.shake(500, t / 100);
+    this.cameras.main.setZoom(1 + t);
+}
+
+function draw()
+{
+    rt.save();
+
+    rt.globalAlpha = Math.random();
+    rt.globalTint = (0x00ffff * (Math.random() * 0.1 + 0.9));
+
+    var frame = matrixTexture.frames[Math.floor(Math.random() * 10)];
+
+    var rand = Math.random() + 0.1;
+
+    rt.currentMatrix = [rand, 0, 0, rand, Math.random() * 800, Math.random() * 600];
+
+    rt.draw(matrixTexture, frame, -matrixTexture.frames[0].halfWidth, -matrixTexture.frames[0].halfHeight);
+    rt.restore();
+}

--- a/public/src/game objects/render texture/change frame.js
+++ b/public/src/game objects/render texture/change frame.js
@@ -1,0 +1,63 @@
+var config = {
+    type: Phaser.AUTO,
+    parent: 'phaser-example',
+    scene: {
+        preload: preload,
+        create: create
+    },
+    width: 800,
+    height: 600
+};
+
+var rt;
+
+var atari;
+var mushroom;
+var car;
+var selected;
+
+var game = new Phaser.Game(config);
+
+function preload()
+{
+    this.load.atlas('atlas', 'assets/atlas/megaset-1.png', 'assets/atlas/megaset-1.json');
+}
+
+function create() 
+{
+    rt = this.make.renderTexture({ x: 0, y: 0, width: 800, height: 600 }).setOrigin(0, 0);
+
+    atari = this.add.image(200, 500, 'atlas', 'atari800').setInteractive();
+    mushroom = this.add.image(400, 100, 'atlas', 'mushroom2').setInteractive();
+    car = this.add.image(650, 500, 'atlas', 'supercars-parsec').setInteractive();
+
+    selected = atari;
+
+    atari.on('pointerdown', function ()
+    {
+        selected = this;
+    })
+
+    mushroom.on('pointerdown', function ()
+    {
+        selected = this;
+    })
+
+    car.on('pointerdown', function ()
+    {
+        selected = this;
+    })
+
+    this.input.on('pointermove', function (pointer)
+    {
+        draw(pointer.x, pointer.y);
+    });
+}
+
+function draw(x, y) 
+{
+    rt.save();
+    rt.translate(x, y);
+    rt.draw(selected.texture, selected.frame, -selected.width, -selected.height / 2);
+    rt.restore();
+}

--- a/public/src/game objects/render texture/explosion.js
+++ b/public/src/game objects/render texture/explosion.js
@@ -1,0 +1,91 @@
+var config = {
+    type: Phaser.AUTO,
+    parent: 'phaser-example',
+    scene: {
+        preload: preload,
+        create: create
+    },
+    width: 800,
+    height: 600
+};
+
+var game = new Phaser.Game(config);
+
+var rt;
+var blast;
+var nuke;
+
+function preload() 
+{
+    this.load.image('fire', 'assets/particles/muzzleflash3.png');
+    this.load.image('smoke', 'assets/particles/smoke-puff.png');
+}
+
+function create() 
+{
+    rt = this.make.renderTexture({ x: 0, y: 0, width: 800, height: 600 }).setOrigin(0, 0);
+
+    blast = this.add.follower(null, 50, 350, 'smoke');
+
+    nuke = this.tweens.add({
+        targets: blast,
+        scaleX: 8,
+        scaleY: 8,
+        alpha: 0,
+        duration: 1000,
+        ease: "Bounce.easeIn",
+        onComplete: function () { rt.clear(); blast.alpha = 0 },
+        paused: true
+    });
+
+    nuke.setCallback('onUpdate', draw, [], this);
+
+    this.input.on('pointerdown', function (pointer)
+    {
+
+        explode(pointer.x, pointer.y);
+
+    }, this);
+}
+
+function explode(x, y) 
+{
+    blast.x = x;
+    blast.y = y;
+    blast.setScale(0.5);
+    blast.alpha = 1;
+
+    var curve = new Phaser.Curves.Spline([200, 500, 600, 500, 625, 475, 200, 500, 400, 500, 400, 250]);
+
+    blast.setPath(curve);
+    blast.startFollow(200);
+
+    nuke.play();
+}
+
+function draw() 
+{
+    rt.save();
+
+    var crot = Math.cos(blast.rotation + Math.random() * 2);
+    var srot = Math.sin(blast.rotation + Math.random() * 2);
+
+    var rand = Math.random() * 2;
+
+    var sx = blast.scaleX + rand;
+    var sy = blast.scaleY + rand;
+
+    if (Math.random() < 0.8)
+    {
+        blast.setTexture('fire');
+    } else
+    {
+        blast.setTexture('smoke');
+    }
+
+    rt.currentMatrix = [crot * sx, srot, -srot, crot * sy, blast.x, blast.y];
+
+    rt.setAlpha(blast.alpha);
+    rt.draw(blast.texture, blast.frame, -blast.width / 2, -blast.height / 2);
+    rt.restore();
+}

--- a/public/src/game objects/render texture/fireball.js
+++ b/public/src/game objects/render texture/fireball.js
@@ -1,0 +1,81 @@
+var config = {
+    type: Phaser.AUTO,
+    parent: 'phaser-example',
+    scene: {
+        preload: preload,
+        create: create
+    },
+    width: 800,
+    height: 600
+};
+
+var game = new Phaser.Game(config);
+
+var rt;
+var ball1;
+var fireblast;
+
+function preload()
+{
+    this.load.image('dude', 'assets/sprites/phaser-dude.png');
+    this.load.image('fire', 'assets/particles/muzzleflash3.png');
+}
+
+function create()
+{
+    rt = this.make.renderTexture({ x: 0, y: 0, width: 800, height: 600 }).setOrigin(0, 0);
+
+    player = this.add.image(100, 300, 'dude');
+
+    ball1 = this.add.follower(null, 50, 350, 'fire');
+
+    fireblast = this.tweens.add({
+        targets: ball1,
+        scaleX: 3,
+        scaleY: 3,        
+        alpha: 0,
+        duration: 300,
+        ease: "Cubic.easeInOut",
+        onComplete: function () { rt.clear(); ball1.alpha = 0 },
+        paused: true
+    });
+
+    fireblast.setCallback('onUpdate', draw, [], this);
+
+    this.input.on('pointerdown', function (pointer)
+    {
+        generate(pointer.x, pointer.y);
+    }, this);
+}
+
+function generate(x, y)
+{
+    ball1.x = player.x;
+    ball1.y = player.y;
+    ball1.setScale(0.5);
+    ball1.alpha = 1;
+
+    curve = new Phaser.Curves.Line(new Phaser.Math.Vector2(player.x, player.y), new Phaser.Math.Vector2(x, y));
+
+    ball1.setPath(curve);
+    ball1.startFollow(300);
+    
+    fireblast.play();    
+}
+
+function draw()
+{
+    rt.save();
+
+    var crot = Math.cos(ball1.rotation + Math.random());
+    var srot = Math.sin(ball1.rotation + Math.random());
+
+    var sx = ball1.scaleX + Math.random();
+    var sy = ball1.scaleY + Math.random();
+
+    rt.currentMatrix = [crot * sx, srot, -srot, crot * sy, ball1.x, ball1.y];
+
+    rt.alpha = ball1.alpha;
+    rt.draw(ball1.texture, ball1.frame, -ball1.width / 2, -ball1.height / 2);
+    rt.restore();
+}

--- a/public/src/game objects/render texture/sparks.js
+++ b/public/src/game objects/render texture/sparks.js
@@ -17,37 +17,37 @@ var player;
 
 function preload() 
 {
-    this.load.baseURL = '//examples.phaser.io/';
-    this.load.crossOrigin = 'anonymous';
     this.load.image('dude', 'assets/sprites/phaser-dude.png');
 }
 
 function create() 
 {
-    rt = this.make.renderTexture({x: 0, y: 0, width: 800, height: 600});
-    
-    player= this.add.sprite(256,256,'dude');
-    player.setOrigin(0.5,0.5);
+    rt = this.make.renderTexture({ x: 0, y: 0, width: 800, height: 600 });
+
+    player = this.add.sprite(256, 256, 'dude');
+    player.setOrigin(0.5, 0.5);
 }
 
 function update()
 {
     player.x = this.input.x;
     player.y = this.input.y;
-    
+
     draw();
 }
 
-function draw() {
-    rt.clear();    
-    rt.globalAlpha=Math.random();
-    rt.globalTint =  ((0.5 + Math.random()) * 0xFFFFFF << 0);
+function draw() 
+{
+    rt.clear();
+    rt.globalAlpha = Math.random();
+    rt.globalTint = ((0.5 + Math.random()) * 0xFFFFFF << 0);
 
-    for(i=0;i<5;i++){
-        var rot=Math.floor((Math.random() * Math.PI*2) + 1);
-        var dist= 75+Math.floor((Math.random() * 50) + 1);
+    for (i = 0; i < 5; i++)
+    {
+        var rot = Math.floor((Math.random() * Math.PI * 2) + 1);
+        var dist = 75 + Math.floor((Math.random() * 50) + 1);
 
-        rt.draw(player.texture, player.frame, player.x+dist*Math.cos(rot) ,player.y+dist*Math.sin(rot)); 
+        rt.draw(player.texture, player.frame, player.x + dist * Math.cos(rot), player.y + dist * Math.sin(rot));
         rt.restore();
     }
 }

--- a/public/src/game objects/render texture/trail.js
+++ b/public/src/game objects/render texture/trail.js
@@ -20,19 +20,17 @@ var dist;
 
 function preload() 
 {
-    this.load.baseURL = '//examples.phaser.io/';
-    this.load.crossOrigin = 'anonymous';
     this.load.image('dude', 'assets/sprites/phaser-dude.png');
 }
 
 function create() 
 {
-    rt = this.make.renderTexture({x: 0, y: 0, width: 800, height: 600}).setOrigin(0,0);
-    
-    trail = this.add.image(0,0,'dude').setOrigin(0.5,0.5);
-    
-    player= this.add.image(256,256,'dude');
-    player.setOrigin(0.5,0.5);
+    rt = this.make.renderTexture({ x: 0, y: 0, width: 800, height: 600 }).setOrigin(0, 0);
+
+    trail = this.add.image(0, 0, 'dude').setOrigin(0.5, 0.5);
+
+    player = this.add.image(256, 256, 'dude');
+    player.setOrigin(0.5, 0.5);
 
     tween = this.tweens.add({
         targets: trail,
@@ -40,7 +38,7 @@ function create()
         y: player.y,
         ease: 'Sine.easeInOut',
         duration: 50000,
-        loop:true
+        loop: true
     });
 }
 
@@ -49,21 +47,24 @@ function update()
     player.x = this.input.x;
     player.y = this.input.y;
 
-    dist = Phaser.Math.Distance.Between(trail.x,trail.y,player.x,player.y);
-    
-    tween.timeScale = dist/100;
+    dist = Phaser.Math.Distance.Between(trail.x, trail.y, player.x, player.y);
+
+    tween.timeScale = dist / 100;
 
     tween.updateTo('x', player.x, true);
     tween.updateTo('y', player.y, true);
-    
+
     draw();
 }
 
-function draw() {
+function draw()
+{
     rt.save();
-    rt.globalAlpha = 100/(dist+0.01);
-    rt.globalTint = dist|0xff0000;
-    rt.translate(trail.x,trail.y);
-    rt.draw(trail.texture, trail.frame,-trail.width/2,-trail.height/2); 
-    rt.restore();    
+
+    rt.globalAlpha = 100 / (dist + 0.01);
+    rt.globalTint = dist | 0xff0000;
+
+    rt.translate(trail.x, trail.y);
+    rt.draw(trail.texture, trail.frame, -trail.width / 2, -trail.height / 2);
+    rt.restore();
 }

--- a/public/src/game objects/render texture/trail2.js
+++ b/public/src/game objects/render texture/trail2.js
@@ -17,17 +17,15 @@ var player;
 
 function preload() 
 {
-    this.load.baseURL = '//examples.phaser.io/';
-    this.load.crossOrigin = 'anonymous';
     this.load.image('dude', 'assets/sprites/phaser-dude.png');
 }
 
 function create() 
 {
-    rt = this.make.renderTexture({x: 0, y: 0, width: 800, height: 600}).setOrigin(0,0);
-        
-    player= this.add.image(256,256,'dude');
-    player.setOrigin(0.5,0.5);
+    rt = this.make.renderTexture({ x: 0, y: 0, width: 800, height: 600 }).setOrigin(0, 0);
+
+    player = this.add.image(256, 256, 'dude');
+    player.setOrigin(0.5, 0.5);
 }
 
 function update()
@@ -38,11 +36,10 @@ function update()
     draw();
 }
 
-function draw() {
-
+function draw() 
+{
     rt.save();
-    rt.translate(player.x,player.y);
-    rt.draw(player.texture, player.frame,-player.width/2,-player.height/2); 
-    rt.restore();    
-
+    rt.translate(player.x, player.y);
+    rt.draw(player.texture, player.frame, -player.width / 2, -player.height / 2);
+    rt.restore();
 }

--- a/public/src/textures/edit texture hue shift.js
+++ b/public/src/textures/edit texture hue shift.js
@@ -11,9 +11,9 @@ var config = {
 
 var game = new Phaser.Game(config);
 
-var newCanvas;
 var originalTexture;
 var newTexture;
+var context; 
 
 var dude;
 var dude2;
@@ -43,23 +43,19 @@ function hueShift()
 {
     var pixels = context.getImageData(0, 0, originalTexture.width, originalTexture.height);
 
-    for (i = 0; i < pixels.data.length - 1; i++)
+    for (i = 0; i < pixels.data.length / 4; i++)
     {
-        if (i % 4 == 0)
-        {
-            processPixel(pixels.data, i, 0.1);
-        }
-
+        processPixel(pixels.data, i * 4, 0.1);
     }
 
     context.putImageData(pixels, 0, 0);
 }
 
-function processPixel(data, pixel, deltahue)
+function processPixel(data, index, deltahue)
 {
-    var r = data[pixel];
-    var g = data[pixel + 1];
-    var b = data[pixel + 2];
+    var r = data[index];
+    var g = data[index + 1];
+    var b = data[index + 2];
 
     var hsv = Phaser.Display.Color.RGBToHSV(r, g, b);
 
@@ -67,7 +63,7 @@ function processPixel(data, pixel, deltahue)
 
     var rgb = Phaser.Display.Color.HSVToRGB(h, hsv.s, hsv.v);
 
-    data[pixel] = rgb.r;
-    data[pixel + 1] = rgb.g;
-    data[pixel + 2] = rgb.b;
+    data[index] = rgb.r;
+    data[index + 1] = rgb.g;
+    data[index + 2] = rgb.b;
 }

--- a/public/src/textures/edit texture hue shift.js
+++ b/public/src/textures/edit texture hue shift.js
@@ -1,0 +1,73 @@
+var config = {
+    type: Phaser.CANVAS,
+    parent: 'phaser-example',
+    scene: {
+        preload: preload,
+        create: create
+    },
+    width: 800,
+    height: 600
+};
+
+var game = new Phaser.Game(config);
+
+var newCanvas;
+var originalTexture;
+var newTexture;
+
+var dude;
+var dude2;
+
+function preload() 
+{
+    this.load.image('dude', 'assets/sprites/phaser-dude.png');
+}
+
+function create() 
+{
+    originalTexture = this.textures.get('dude').getSourceImage();
+
+    var newTexture = this.textures.createCanvas('dude_new', originalTexture.width, originalTexture.height);
+
+    context = newTexture.getSourceImage().getContext('2d');
+
+    context.drawImage(originalTexture, 0, 0);
+
+    dude = this.add.image(100, 100, 'dude');
+    dude2 = this.add.image(200, 100, 'dude_new');
+
+    this.time.addEvent({ delay: 500, callback: hueShift , loop: true });
+}
+
+function hueShift()
+{
+    var pixels = context.getImageData(0, 0, originalTexture.width, originalTexture.height);
+
+    for (i = 0; i < pixels.data.length - 1; i++)
+    {
+        if (i % 4 == 0)
+        {
+            processPixel(pixels.data, i, 0.1);
+        }
+
+    }
+
+    context.putImageData(pixels, 0, 0);
+}
+
+function processPixel(data, pixel, deltahue)
+{
+    var r = data[pixel];
+    var g = data[pixel + 1];
+    var b = data[pixel + 2];
+
+    var hsv = Phaser.Display.Color.RGBToHSV(r, g, b);
+
+    var h = hsv.h + deltahue;
+
+    var rgb = Phaser.Display.Color.HSVToRGB(h, hsv.s, hsv.v);
+
+    data[pixel] = rgb.r;
+    data[pixel + 1] = rgb.g;
+    data[pixel + 2] = rgb.b;
+}

--- a/public/src/textures/edit texture silhouette.js
+++ b/public/src/textures/edit texture silhouette.js
@@ -11,9 +11,9 @@ var config = {
 
 var game = new Phaser.Game(config);
 
-var newCanvas;
 var originalTexture;
 var newTexture;
+var context;
 
 var dude;
 var dude2;
@@ -24,16 +24,16 @@ function preload()
 }
 
 function create() 
-{    
+{
     originalTexture = this.textures.get('dude').getSourceImage();
 
     var newTexture = this.textures.createCanvas('dude_new', originalTexture.width, originalTexture.height);
-    
+
     context = newTexture.getSourceImage().getContext('2d');
 
-    context.drawImage(originalTexture, 0,0);    
+    context.drawImage(originalTexture, 0, 0);
 
-    dude = this.add.image(100, 100, 'dude');    
+    dude = this.add.image(100, 100, 'dude');
     dude2 = this.add.image(200, 100, 'dude_new');
 
     createSilhouette();
@@ -43,18 +43,17 @@ function createSilhouette()
 {
     var pixels = context.getImageData(0, 0, originalTexture.width, originalTexture.height);
 
-    for(i=0; i < pixels.data.length; i++){
-        if(i % 4 == 0){
-            processPixel(pixels.data, i);            
-        }
+    for (i = 0; i < pixels.data.length / 4; i++)
+    {
+        processPixel(pixels.data, i * 4, 0.1);
     }
 
     context.putImageData(pixels, 0, 0);
 }
 
-function processPixel(data,pixel)
+function processPixel(data, index)
 {
-    data[pixel] = 255;
-    data[pixel + 1] = 0;
-    data[pixel + 2] = 0;
+    data[index] = 255;
+    data[index + 1] = 0;
+    data[index + 2] = 0;
 }

--- a/public/src/textures/edit texture silhouette.js
+++ b/public/src/textures/edit texture silhouette.js
@@ -1,0 +1,60 @@
+var config = {
+    type: Phaser.CANVAS,
+    parent: 'phaser-example',
+    scene: {
+        preload: preload,
+        create: create
+    },
+    width: 800,
+    height: 600
+};
+
+var game = new Phaser.Game(config);
+
+var newCanvas;
+var originalTexture;
+var newTexture;
+
+var dude;
+var dude2;
+
+function preload() 
+{
+    this.load.image('dude', 'assets/sprites/phaser-dude.png');
+}
+
+function create() 
+{    
+    originalTexture = this.textures.get('dude').getSourceImage();
+
+    var newTexture = this.textures.createCanvas('dude_new', originalTexture.width, originalTexture.height);
+    
+    context = newTexture.getSourceImage().getContext('2d');
+
+    context.drawImage(originalTexture, 0,0);    
+
+    dude = this.add.image(100, 100, 'dude');    
+    dude2 = this.add.image(200, 100, 'dude_new');
+
+    createSilhouette();
+}
+
+function createSilhouette()
+{
+    var pixels = context.getImageData(0, 0, originalTexture.width, originalTexture.height);
+
+    for(i=0; i < pixels.data.length; i++){
+        if(i % 4 == 0){
+            processPixel(pixels.data, i);            
+        }
+    }
+
+    context.putImageData(pixels, 0, 0);
+}
+
+function processPixel(data,pixel)
+{
+    data[pixel] = 255;
+    data[pixel + 1] = 0;
+    data[pixel + 2] = 0;
+}


### PR DESCRIPTION
Remove cross domain baseUrl, fix code formatting for #21. 

I've worked on some examples for Rendertextures and basic examples for editing textures. The Brute force example uses the [following font](https://fontmeme.com/fonts/gabato-font/) (free for commercial use).

Rendertextures:

[Brute Force](http://jsfiddle.net/d0uvb4ga/2/)

[Fireball](https://codepen.io/Samid737/pen/NYGjva)

Above example uses v3.2.1 due to bug in v3.3.0 when using path.setPath (suspect [L179](https://github.com/photonstorm/phaser/blob/2cd7da01261729e01ef002a9a6a10a4c9f19351a/src/gameobjects/pathfollower/PathFollower.js#L179)) and when restarting tween (suspect [#3408](https://github.com/photonstorm/phaser/issues/3408))).

[Explosion](https://codepen.io/Samid737/pen/aYdOJP)

Above example uses v3.2.1 due to bug in v3.3.0 when using path.setPath (suspect [L179](https://github.com/photonstorm/phaser/blob/2cd7da01261729e01ef002a9a6a10a4c9f19351a/src/gameobjects/pathfollower/PathFollower.js#L179)) and when restarting tween (suspect [#3408](https://github.com/photonstorm/phaser/issues/3408))).


[Change frame](http://jsfiddle.net/La4vmzyz/4/)

Camera:  

[Background Color interpolate](http://jsfiddle.net/0aa4dp3o/3/)

Textures:

[Hue shift](http://jsfiddle.net/kpvqgfgj/3/)

[Silhouette](http://jsfiddle.net/st06hv8v/2/)

I could not get the above two Texture examples to work in WEBGL, only in CANVAS.