### PR TITLE
Fixed tinting sprites for the MatterJS Collision Filter example

### DIFF
--- a/public/src/physics/matterjs/collision filter.js
+++ b/public/src/physics/matterjs/collision filter.js
@@ -48,10 +48,10 @@ function create ()
 
     blockA.setVelocityX(25);
 
-    this.matter.world.on('COLLISION_START_EVENT', function (event) {
+    this.matter.world.on('collisionstart', function (event) {
 
-        event.bodyA.gameObject.setTint(0xff0000);
-        event.bodyB.gameObject.setTint(0x00ff00);
+        event.pairs[0].bodyA.gameObject.setTint(0xff0000);
+        event.pairs[0].bodyB.gameObject.setTint(0x00ff00);
 
     });
 }


### PR DESCRIPTION
The event and its properties have changed since the example was created. This wasn't causing any errors, but I've simply updated the example so that the tinting works.

http://labs.phaser.io/edit.html?src=src\physics\matterjs\collision%20filter.js