### PR TITLE
Fixed Geom/Line/Perp Slope Example from Issue #43 

### DIFF
--- a/public/src/geom/line/perp slope.js
+++ b/public/src/geom/line/perp slope.js
@@ -63,7 +63,8 @@ function update ()
         midPoint.x + normal.x * 250,
         midPoint.y + normal.y * 250);
 
-    Phaser.Geom.Point.Multiply(normal, position, position);
+    normal.x *= position;
+    normal.y += position;
 
     graphics.fillCircle(midPoint.x + normal.x, midPoint.y + normal.y, 12);
 }


### PR DESCRIPTION
Fixed this example (Issue #43 ) by replacing reference to Geom/Point/Multiply (no longer in API) with equivalent arithmetic. Runs as shown below.

<img width="802" alt="screen shot 2018-04-10 at 11 48 38 am" src="https://user-images.githubusercontent.com/16906897/38568063-b4646eba-3cb5-11e8-9ffc-ab6f4eba785e.png">
