### PR TITLE
Update impact physics game object keys (solves #139 #150)

### DIFF
--- a/public/src/camera/graphics landscape.js
+++ b/public/src/camera/graphics landscape.js
@@ -44,7 +44,7 @@ function create ()
     //  Add a player ship
 
     this.player = this.impact.add.sprite(1600, 200, 'ship');
-    this.player.setMaxVelocity(1000).setFriction(400, 200).setPassive();
+    this.player.setMaxVelocity(1000).setFriction(400, 200).setPassiveCollision();
 
     this.cursors = this.input.keyboard.createCursorKeys();
 }

--- a/public/src/camera/minimap camera.js
+++ b/public/src/camera/minimap camera.js
@@ -58,7 +58,7 @@ function create ()
     //  Add a player ship
 
     this.player = this.impact.add.sprite(1600, 200, 'ship');
-    this.player.setMaxVelocity(1000).setFriction(400, 200).setPassive();
+    this.player.setMaxVelocity(1000).setFriction(400, 200).setPassiveCollision();
 
     this.cursors = this.input.keyboard.createCursorKeys();
 }
@@ -205,7 +205,7 @@ function createAliens ()
 
         var face = this.impact.add.sprite(x, y, 'face').play('metaleyes');
 
-        face.setLite().setBounce(1).setBodyScale(0.5);
+        face.setLiteCollision().setBounce(1).setBodyScale(0.5);
         face.setVelocity(Phaser.Math.Between(20, 60), Phaser.Math.Between(20, 60));
 
         if (Math.random() > 0.5)

--- a/public/src/game objects/container/impact physics body test.js
+++ b/public/src/game objects/container/impact physics body test.js
@@ -39,7 +39,7 @@ function create ()
 
     this.impact.world.setBounds();
 
-    var body = this.impact.add.body(200, 200).setActive().setVelocity(300, 150).setBounce(1);
+    var body = this.impact.add.body(200, 200).setActiveCollision().setVelocity(300, 150).setBounce(1);
 
     //  Assign the graphics object to the body. 'false' tells it not to use the Graphics size.
     body.setGameObject(container, true);

--- a/public/src/games/defenda/test.js
+++ b/public/src/games/defenda/test.js
@@ -121,7 +121,7 @@ function create ()
     //  Add a player ship
 
     this.player = this.impact.add.sprite(1600, 200, 'ship').setDepth(1);
-    this.player.setMaxVelocity(1000).setFriction(800, 600).setPassive();
+    this.player.setMaxVelocity(1000).setFriction(800, 600).setPassiveCollision();
 
     this.cursors = this.input.keyboard.createCursorKeys();
 
@@ -338,7 +338,7 @@ function createAliens ()
 
         var face = this.impact.add.sprite(x, y, 'face').play('metaleyes');
 
-        face.setLite().setBounce(1).setBodyScale(0.5);
+        face.setLiteCollision().setBounce(1).setBodyScale(0.5);
         face.setVelocity(Phaser.Math.Between(20, 60), Phaser.Math.Between(20, 60));
 
         if (Math.random() > 0.5)

--- a/public/src/physics/impact/100 world bodies.js
+++ b/public/src/physics/impact/100 world bodies.js
@@ -50,7 +50,7 @@ function create ()
 
         var block = this.impact.add.sprite(pos.x, pos.y, 'gems');
 
-        block.setActive().setAvsB().setBounce(1);
+        block.setActiveCollision().setAvsB().setBounce(1);
 
         block.setVelocity(Phaser.Math.Between(200, 400), Phaser.Math.Between(200, 400));
 

--- a/public/src/physics/impact/1000 world bodies.js
+++ b/public/src/physics/impact/1000 world bodies.js
@@ -51,7 +51,7 @@ function create ()
 
         var block = this.impact.add.sprite(pos.x, pos.y, 'gems');
 
-        block.setActive().setAvsB().setBounce(1);
+        block.setActiveCollision().setAvsB().setBounce(1);
 
         block.setVelocity(Phaser.Math.Between(200, 400), Phaser.Math.Between(200, 400));
 

--- a/public/src/physics/impact/10000 world bodies.js
+++ b/public/src/physics/impact/10000 world bodies.js
@@ -51,7 +51,7 @@ function create ()
 
         var block = this.impact.add.sprite(pos.x, pos.y, 'gems');
 
-        block.setActive().setAvsB().setBounce(1);
+        block.setActiveCollision().setAvsB().setBounce(1);
 
         block.setVelocity(Phaser.Math.Between(200, 400), Phaser.Math.Between(200, 400));
 

--- a/public/src/physics/impact/bitmaptext body.js
+++ b/public/src/physics/impact/bitmaptext body.js
@@ -18,7 +18,7 @@ var config = {
 
 var game = new Phaser.Game(config);
 
-function preload() 
+function preload()
 {
     this.load.bitmapFont('hyper', 'assets/fonts/bitmap/hyperdrive.png', 'assets/fonts/bitmap/hyperdrive.xml');
 }
@@ -33,5 +33,5 @@ function create ()
 
     //  If you don't set the body as active it won't collide with the world bounds
     //  Set the Game Object we just created as being bound to this physics body
-    this.impact.add.body(100, 200).setGameObject(text).setActive().setVelocity(300, 200).setBounce(1);
+    this.impact.add.body(100, 200).setGameObject(text).setActiveCollision().setVelocity(300, 200).setBounce(1);
 }

--- a/public/src/physics/impact/body collision.js
+++ b/public/src/physics/impact/body collision.js
@@ -25,9 +25,9 @@ function create ()
     var blockB = this.impact.add.image(60, 300, 'block');
     var blockC = this.impact.add.image(730, 300, 'block');
 
-    blockA.setTypeA().setCheckAgainstB().setActive().setMaxVelocity(300);
-    blockB.setTypeB().setCheckAgainstA().setFixed();
-    blockC.setTypeB().setCheckAgainstA().setFixed();
+    blockA.setTypeA().setCheckAgainstB().setActiveCollision().setMaxVelocity(300);
+    blockB.setTypeB().setCheckAgainstA().setFixedCollision();
+    blockC.setTypeB().setCheckAgainstA().setFixedCollision();
 
     blockA.setBounce(1).setVelocityX(300);
 }

--- a/public/src/physics/impact/body offset.js
+++ b/public/src/physics/impact/body offset.js
@@ -27,11 +27,11 @@ function create ()
 {
     var block = this.impact.add.image(400, 100, 'block');
 
-    block.setActive().setAvsB().setMaxVelocity(600).setBounce(0.8);
+    block.setActiveCollision().setAvsB().setMaxVelocity(600).setBounce(0.8);
 
     //  Change the size and position of the physics body in relation to the Image it is bound to
     block.setOffset(16, 16, 64, 64);
 
     //  Create a floor. We don't need to render it, so just make a Fixed Body
-    this.impact.add.body(0, 500, 800, 64).setFixed().setGravity(0);
+    this.impact.add.body(0, 500, 800, 64).setFixedCollision().setGravity(0);
 }

--- a/public/src/physics/impact/collide callback.js
+++ b/public/src/physics/impact/collide callback.js
@@ -24,8 +24,8 @@ function create ()
     var blockA = this.impact.add.image(60, 300, 'block');
     var blockB = this.impact.add.image(730, 300, 'block');
 
-    blockA.setTypeA().setCheckAgainstB().setActive().setMaxVelocity(300);
-    blockB.setTypeB().setCheckAgainstA().setFixed();
+    blockA.setTypeA().setCheckAgainstB().setActiveCollision().setMaxVelocity(300);
+    blockB.setTypeB().setCheckAgainstA().setFixedCollision();
 
     blockA.setVelocityX(300);
 

--- a/public/src/physics/impact/collide event.js
+++ b/public/src/physics/impact/collide event.js
@@ -24,8 +24,8 @@ function create ()
     var blockA = this.impact.add.image(60, 300, 'block');
     var blockB = this.impact.add.image(730, 300, 'block');
 
-    blockA.setTypeA().setCheckAgainstB().setActive().setMaxVelocity(300);
-    blockB.setTypeB().setCheckAgainstA().setFixed();
+    blockA.setTypeA().setCheckAgainstB().setActiveCollision().setMaxVelocity(300);
+    blockB.setTypeB().setCheckAgainstA().setFixedCollision();
 
     blockA.setVelocityX(300);
 

--- a/public/src/physics/impact/dynamic bitmaptext body.js
+++ b/public/src/physics/impact/dynamic bitmaptext body.js
@@ -25,7 +25,7 @@ var rainbowWave = 0;
 
 var game = new Phaser.Game(config);
 
-function preload() 
+function preload()
 {
     this.load.bitmapFont('desyrel', 'assets/fonts/bitmap/desyrel.png', 'assets/fonts/bitmap/desyrel.xml');
     this.load.bitmapFont('hyper', 'assets/fonts/bitmap/hyperdrive.png', 'assets/fonts/bitmap/hyperdrive.xml');
@@ -45,8 +45,8 @@ function create ()
 
     //  If you don't set the body as active it won't collide with the world bounds
     //  Set the Game Object we just created as being bound to this physics body
-    this.impact.add.body(200, 100).setGameObject(text1).setLite().setVelocity(-300, 200).setBounce(1);
-    this.impact.add.body(100, 300).setGameObject(text2).setLite().setVelocity(300, 200).setBounce(1);
+    this.impact.add.body(200, 100).setGameObject(text1).setLiteCollision().setVelocity(-300, 200).setBounce(1);
+    this.impact.add.body(100, 300).setGameObject(text2).setLiteCollision().setVelocity(300, 200).setBounce(1);
 }
 
 function update()

--- a/public/src/physics/impact/dynamic graphics body.js
+++ b/public/src/physics/impact/dynamic graphics body.js
@@ -27,7 +27,7 @@ function create ()
     var graphics = this.add.graphics();
 
     //  If you don't set the body as active it won't collide with the world bounds
-    var star = this.impact.add.body(200, 200).setActive().setVelocity(300, 150).setBounce(1);
+    var star = this.impact.add.body(200, 200).setActiveCollision().setVelocity(300, 150).setBounce(1);
 
     //  Set a body size of 100x100
     star.setBodySize(100, 100);

--- a/public/src/physics/impact/graphics body.js
+++ b/public/src/physics/impact/graphics body.js
@@ -30,7 +30,7 @@ function create ()
     drawStar(graphics, 0, 0, 5, 64, 64 / 2, 0xffff00, 0xff0000);
 
     //  If you don't set the body as active it won't collide with the world bounds
-    var body = this.impact.add.body(200, 200).setActive().setVelocity(300, 150).setBounce(1);
+    var body = this.impact.add.body(200, 200).setActiveCollision().setVelocity(300, 150).setBounce(1);
 
     //  Assign the graphics object to the body. 'false' tells it not to use the Graphics size.
     body.setGameObject(graphics, false);

--- a/public/src/physics/impact/group shift position from body.js
+++ b/public/src/physics/impact/group shift position from body.js
@@ -19,7 +19,7 @@ var config = {
 
 var game = new Phaser.Game(config);
 
-function preload() 
+function preload()
 {
     this.load.image('sky', 'assets/skies/deepblue.png');
     this.load.image('ball', 'assets/demoscene/ball-tlb.png');
@@ -37,7 +37,7 @@ function create ()
     group.createMultiple({ key: 'ball', frameQuantity: 64 });
 
     //  If you don't set the body as active it won't collide with the world bounds
-    var balls = this.impact.add.body(200, 100).setActive().setVelocity(300, 200).setBounce(0.95);
+    var balls = this.impact.add.body(200, 100).setActiveCollision().setVelocity(300, 200).setBounce(0.95);
 
     //  Set a body size of 1x1
     balls.setBodySize(1, 1);

--- a/public/src/physics/impact/move body with cursors.js
+++ b/public/src/physics/impact/move body with cursors.js
@@ -52,16 +52,16 @@ function create ()
     this.impact.world.setBounds();
 
     //  A few platforms
-    this.impact.add.image(200, 300, 'platform').setFixed().setGravity(0).setBodyScale(0.5);
-    this.impact.add.image(550, 190, 'platform').setFixed().setGravity(0).setBodyScale(0.4);
-    this.impact.add.image(900, 300, 'platform').setFixed().setGravity(0).setBodyScale(0.5);
-    this.impact.add.image(800, 400, 'platform').setFixed().setGravity(0).setBodyScale(0.5);
-    this.impact.add.image(700, 500, 'platform').setFixed().setGravity(0).setBodyScale(0.5);
+    this.impact.add.image(200, 300, 'platform').setFixedCollision().setGravity(0).setBodyScale(0.5);
+    this.impact.add.image(550, 190, 'platform').setFixedCollision().setGravity(0).setBodyScale(0.4);
+    this.impact.add.image(900, 300, 'platform').setFixedCollision().setGravity(0).setBodyScale(0.5);
+    this.impact.add.image(800, 400, 'platform').setFixedCollision().setGravity(0).setBodyScale(0.5);
+    this.impact.add.image(700, 500, 'platform').setFixedCollision().setGravity(0).setBodyScale(0.5);
 
     //  Our sprite
     player = this.impact.add.sprite(200, 200, 'dude', 4).setOrigin(0, 0.15);
 
-    player.setActive();
+    player.setActiveCollision();
     player.setMaxVelocity(500);
     player.setFriction(1000, 100);
 

--- a/public/src/physics/impact/multiple scenes.js
+++ b/public/src/physics/impact/multiple scenes.js
@@ -34,7 +34,7 @@ var SceneA = new Phaser.Class({
 
             var block = this.impact.add.sprite(pos.x, pos.y, 'gems');
 
-            block.setActive().setAvsB().setBounce(1);
+            block.setActiveCollision().setAvsB().setBounce(1);
 
             block.setVelocity(Phaser.Math.Between(200, 400), Phaser.Math.Between(200, 400));
 
@@ -84,9 +84,9 @@ var SceneB = new Phaser.Class({
         var blockB = this.impact.add.image(60, 300, 'block');
         var blockC = this.impact.add.image(730, 300, 'block');
 
-        blockA.setTypeA().setCheckAgainstB().setActive().setMaxVelocity(300);
-        blockB.setTypeB().setCheckAgainstA().setFixed();
-        blockC.setTypeB().setCheckAgainstA().setFixed();
+        blockA.setTypeA().setCheckAgainstB().setActiveCollision().setMaxVelocity(300);
+        blockB.setTypeB().setCheckAgainstA().setFixedCollision();
+        blockC.setTypeB().setCheckAgainstA().setFixedCollision();
 
         blockA.setBounce(1).setVelocityX(300);
     }
@@ -121,7 +121,7 @@ var SceneC = new Phaser.Class({
 
     create: function ()
     {
-        this.ship = this.impact.add.image(320, 450, 'ship').setActive().setVelocity(200, -200).setBounce(1);
+        this.ship = this.impact.add.image(320, 450, 'ship').setActiveCollision().setVelocity(200, -200).setBounce(1);
 
         this.add.text(0, 0, 'Press 1 to 3 to pause the scenes');
 

--- a/public/src/physics/impact/scaled bodies.js
+++ b/public/src/physics/impact/scaled bodies.js
@@ -27,7 +27,7 @@ function create ()
 {
     this.impact.world.setBounds();
 
-    var bigBlock = this.impact.add.image(300, 100, 'block').setActive().setBounce(1).setVelocity(200, 100);
+    var bigBlock = this.impact.add.image(300, 100, 'block').setActiveCollision().setBounce(1).setVelocity(200, 100);
 
     //  Scale the Image and the body together
     bigBlock.setBodyScale(2);
@@ -36,12 +36,12 @@ function create ()
     // bigBlock.setScale(2);
     // bigBlock.syncGameObject();
 
-    var smallBlock = this.impact.add.image(100, 500, 'block').setActive().setBounce(1).setVelocity(200, -100);
+    var smallBlock = this.impact.add.image(100, 500, 'block').setActiveCollision().setBounce(1).setVelocity(200, -100);
 
     //  Scale the Image and the body together
     smallBlock.setBodyScale(0.5);
 
-    var wideBlock = this.impact.add.image(600, 400, 'block').setActive().setBounce(1).setVelocity(-200, -100);
+    var wideBlock = this.impact.add.image(600, 400, 'block').setActiveCollision().setBounce(1).setVelocity(-200, -100);
 
     //  Scale the Image and the body together
     wideBlock.setBodyScale(2, 0.5);

--- a/public/src/physics/impact/scaling body.js
+++ b/public/src/physics/impact/scaling body.js
@@ -32,9 +32,9 @@ function create ()
 {
     this.impact.world.setBounds();
 
-    var scalingBody = this.impact.add.image(200, 140, 'gameboy', 2).setFixed().setBodyScale(3);
+    var scalingBody = this.impact.add.image(200, 140, 'gameboy', 2).setFixedCollision().setBodyScale(3);
 
-    movingBody = this.impact.add.image(600, 200, 'gameboy', 3).setActive();
+    movingBody = this.impact.add.image(600, 200, 'gameboy', 3).setActiveCollision();
 
     var scale = { x: 3, y: 3 };
 

--- a/public/src/physics/impact/scene config.js
+++ b/public/src/physics/impact/scene config.js
@@ -53,6 +53,7 @@ var config = {
     height: 600,
     parent: 'phaser-example',
     physics: {
+        default: 'impact',
         impact: {
             gravity: 500,
             debug: true,
@@ -72,5 +73,7 @@ function preload ()
 
 function create ()
 {
-    this.impact.add.image(300, 300, 'gem').setActive().setVelocity(300, 200).setBounce(1);
+    this.impact.world.setBounds();
+
+    this.impact.add.image(300, 300, 'gem').setActiveCollision().setVelocity(300, 200).setBounce(1);
 }

--- a/public/src/physics/impact/show debug graphic.js
+++ b/public/src/physics/impact/show debug graphic.js
@@ -34,7 +34,7 @@ function create ()
     var bodyC = this.impact.add.image(700, 260, 'block');
 
     //  Create a floor. We don't need to render it, so just make a Body
-    this.impact.add.body(0, 500, 800, 64).setFixed().setGravity(0);
+    this.impact.add.body(0, 500, 800, 64).setFixedCollision().setGravity(0);
 
     this.impact.world.setAvsB([ bodyA, bodyB, bodyC ]);
     this.impact.world.setActive([ bodyA, bodyB, bodyC ]);

--- a/public/src/physics/impact/small world bounds from config.js
+++ b/public/src/physics/impact/small world bounds from config.js
@@ -36,7 +36,7 @@ function create ()
     //  The world bounds have been set in the config.
 
     //  If you don't set the body as active it won't collide with the world bounds
-    this.impact.add.image(300, 300, 'gem').setActive().setVelocity(300, 200).setBounce(1);
+    this.impact.add.image(300, 300, 'gem').setActiveCollision().setVelocity(300, 200).setBounce(1);
 
     //  It is your responsibility to ensure that new bodies are spawned within the world bounds.
 }

--- a/public/src/physics/impact/text body.js
+++ b/public/src/physics/impact/text body.js
@@ -27,5 +27,5 @@ function create ()
 
     //  If you don't set the body as active it won't collide with the world bounds
     //  Set the Game Object we just created as being bound to this physics body
-    this.impact.add.body(300, 300).setGameObject(text).setActive().setVelocity(300, 200).setBounce(1);
+    this.impact.add.body(300, 300).setGameObject(text).setActiveCollision().setVelocity(300, 200).setBounce(1);
 }

--- a/public/src/physics/impact/tilesprite body.js
+++ b/public/src/physics/impact/tilesprite body.js
@@ -21,7 +21,7 @@ var tilesprite;
 
 var game = new Phaser.Game(config);
 
-function preload() 
+function preload()
 {
     this.load.image('mushroom', 'assets/sprites/mushroom2.png');
 }
@@ -36,7 +36,7 @@ function create ()
 
     //  If you don't set the body as active it won't collide with the world bounds
     //  Set the Game Object we just created as being bound to this physics body
-    var body = this.impact.add.body(200, 100).setGameObject(tilesprite).setActive().setVelocity(300, 150).setBounce(1);
+    var body = this.impact.add.body(200, 100).setGameObject(tilesprite).setActiveCollision().setVelocity(300, 150).setBounce(1);
 
     body.setCollideCallback(collide, this);
 }

--- a/public/src/physics/impact/world bounds from config.js
+++ b/public/src/physics/impact/world bounds from config.js
@@ -30,5 +30,5 @@ function create ()
     //  setBounds: true is the same as calling physics.world.setBounds() with no arguments
 
     //  If you don't set the body as active it won't collide with the world bounds
-    this.impact.add.image(300, 300, 'gem').setActive().setVelocity(300, 200).setBounce(1);
+    this.impact.add.image(300, 300, 'gem').setActiveCollision().setVelocity(300, 200).setBounce(1);
 }

--- a/public/src/physics/impact/world bounds optional walls.js
+++ b/public/src/physics/impact/world bounds optional walls.js
@@ -41,7 +41,7 @@ function create ()
     //  The config has set the top wall to be missing.
 
     //  If you don't set the body as active it won't collide with the world bounds
-    this.impact.add.image(300, 300, 'gem').setActive().setVelocity(300, 200).setBounce(0.95);
+    this.impact.add.image(300, 300, 'gem').setActiveCollision().setVelocity(300, 200).setBounce(0.95);
 
     //  It is your responsibility to ensure that new bodies are spawned within the world bounds.
 }

--- a/public/src/physics/impact/world bounds.js
+++ b/public/src/physics/impact/world bounds.js
@@ -29,5 +29,5 @@ function create ()
     this.impact.world.setBounds();
 
     //  If you don't set the body as active it won't collide with the world bounds
-    this.impact.add.image(300, 300, 'gem').setActive().setVelocity(300, 200).setBounce(1);
+    this.impact.add.image(300, 300, 'gem').setActiveCollision().setVelocity(300, 200).setBounce(1);
 }

--- a/public/src/physics/multi/arcade and matter and impact.js
+++ b/public/src/physics/multi/arcade and matter and impact.js
@@ -52,7 +52,7 @@ function create ()
 
     //  Impact Physics
 
-    this.impact.add.image(300, 300, 'gem').setActive().setVelocity(300, 200).setBounce(1);
+    this.impact.add.image(300, 300, 'gem').setActiveCollision().setVelocity(300, 200).setBounce(1);
 
     //  Arcade Physics:
 


### PR DESCRIPTION
The updates on the Impact phyics Game Object changes listed on 3.6.0 left some errors on a bunch of examples. This PR updates the usage of those changed key names, and solves Issues #139 #150. 
* Impact Physics Game Objects have changed `setLite` to `setLiteCollision`.
* Impact Physics Game Objects have changed `setPassive` to `setPassiveCollision`.
* Impact Physics Game Objects have changed `setFixed` to `setFixedCollision`.
* Impact Physics Game Objects have changed `setActive` to `setActiveCollision`, previously the `setActive` collision method was overwriting the Game Objects `setActive` method, hence the renaming.

The above copied from: https://github.com/photonstorm/phaser/blob/75b250ba5b5c7d0267ff8f4b91afd1da4f0d92bf/README.md#updates

FIXES examples:
http://labs.phaser.io/view.html?src=src\camera\graphics%20landscape.js
http://labs.phaser.io/view.html?src=src\camera\minimap%20camera.js
http://labs.phaser.io/view.html?src=src\game%20objects\container\impact%20physics%20body%20test.js
http://labs.phaser.io/view.html?src=src\games\defenda\test.js
http://labs.phaser.io/view.html?src=src\physics\impact\100%20world%20bodies.js
http://labs.phaser.io/view.html?src=src\physics\impact\1000%20world%20bodies.js
http://labs.phaser.io/view.html?src=src\physics\impact\10000%20world%20bodies.js
http://labs.phaser.io/view.html?src=src\physics\impact\bitmaptext%20body.js
http://labs.phaser.io/view.html?src=src\physics\impact\body%20collision.js
http://labs.phaser.io/view.html?src=src\physics\impact\body%20offset.js
http://labs.phaser.io/view.html?src=src\physics\impact\collide%20callback.js
http://labs.phaser.io/view.html?src=src\physics\impact\collide%20event.js
http://labs.phaser.io/view.html?src=src\physics\impact\dynamic%20bitmaptext%20body.js
http://labs.phaser.io/view.html?src=src\physics\impact\dynamic%20graphics%20body.js
http://labs.phaser.io/view.html?src=src\physics\impact\graphics%20body.js
http://labs.phaser.io/view.html?src=src\physics\impact\multiple%20scenes.js
http://labs.phaser.io/view.html?src=src\physics\impact\scaled%20bodies.js
http://labs.phaser.io/view.html?src=src\physics\impact\scaling%20body.js
http://labs.phaser.io/view.html?src=src\physics\impact\scene%20config.js
http://labs.phaser.io/view.html?src=src\physics\impact\show%20debug%20graphic.js
http://labs.phaser.io/view.html?src=src\physics\impact\small%20world%20bounds%20from%20config.js
http://labs.phaser.io/view.html?src=src\physics\impact\text%20body.js
http://labs.phaser.io/view.html?src=src\physics\impact\tilesprite%20body.js
http://labs.phaser.io/view.html?src=src\physics\impact\world%20bounds%20from%20config.js
http://labs.phaser.io/view.html?src=src\physics\impact\world%20bounds%20optional%20walls.js
http://labs.phaser.io/view.html?src=src\physics\impact\world%20bounds.js
http://labs.phaser.io/view.html?src=src\physics\multi\arcade%20and%20matter%20and%20impact.js

FIXES examples, but still has a different error:
http://labs.phaser.io/view.html?src=src\physics\impact\group%20shift%20position%20from%20body.js
http://labs.phaser.io/view.html?src=src\physics\impact\move%20body%20with%20cursors.js

does NOT fix (currently not working, and not sure what should be changed):
http://labs.phaser.io/view.html?src=src\games\pacman\wip1.js