### PR TITLE
Fix #169: Keep the drop zone creation up to date

### DIFF
--- a/public/src/input/zones/drop zone.js
+++ b/public/src/input/zones/drop zone.js
@@ -35,7 +35,7 @@ function create ()
     }
 
     //  A drop zone
-    var zone = this.add.zone(500, 300, 300, 300).setDropZone();
+    var zone = this.add.zone(500, 300, 300, 300).setRectangleDropZone(300, 300);
 
     //  Just a visual display of the drop zone
     var graphics = this.add.graphics();


### PR DESCRIPTION
#169 Arguments in setDropZone() are no longer optional. Change with setRectangleDropZone(width, height)