### PR TITLE
Fixed hitArea in mass sprite examples.

### DIFF
--- a/public/src/input/mouse/mass scrolling sprite test no cull.js
+++ b/public/src/input/mouse/mass scrolling sprite test no cull.js
@@ -31,7 +31,7 @@ function create ()
     var highlighted = this.add.image(16, 16, 'block');
 
     //  All the Images can share the same Shape, no need for a unique instance per one, a reference is fine
-    var hitArea = new Phaser.Geom.Rectangle(-16, -16, 32, 32);
+    var hitArea = new Phaser.Geom.Rectangle(0, 0, 32, 32);
     var hitAreaCallback = Phaser.Geom.Rectangle.Contains;
 
     //  Create 10,000 Image Game Objects aligned in a grid

--- a/public/src/input/mouse/mass scrolling sprite test.js
+++ b/public/src/input/mouse/mass scrolling sprite test.js
@@ -31,7 +31,7 @@ function create ()
     var highlighted = this.add.image(16, 16, 'block');
 
     //  All the Images can share the same Shape, no need for a unique instance per one, a reference is fine
-    var hitArea = new Phaser.Geom.Rectangle(-16, -16, 32, 32);
+    var hitArea = new Phaser.Geom.Rectangle(0, 0, 32, 32);
     var hitAreaCallback = Phaser.Geom.Rectangle.Contains;
 
     //  Create 10,000 Image Game Objects aligned in a grid

--- a/public/src/input/mouse/mass sprite test.js
+++ b/public/src/input/mouse/mass sprite test.js
@@ -27,7 +27,7 @@ function create ()
 
     var highlighted = this.add.image(16, 16, 'block');
 
-    var hitArea = new Phaser.Geom.Rectangle(-16, -16, 32, 32);
+    var hitArea = new Phaser.Geom.Rectangle(0, 0, 32, 32);
     var hitAreaCallback = Phaser.Geom.Rectangle.Contains;
 
     //  Create 400 sprites aligned in a grid


### PR DESCRIPTION
Fixes https://github.com/photonstorm/phaser3-examples/issues/183