### PR TITLE
Update flood-fill.js

### DIFF
--- a/public/src/games/flood/flood-fill.js
+++ b/public/src/games/flood/flood-fill.js
@@ -367,6 +367,8 @@ var Flood = new Phaser.Class({
         // console.log(this.monsterTween.targets[0].y);
 
         this.monsterTween.stop(0);
+		
+		gameObject.getData('monster').setY(gameObject.y);
 
         // console.log(this.monsterTween.targets[0].y);
 


### PR DESCRIPTION
Prevent monster icon from having a Y value of 0 when mousing out by resetting its Y value after the tween has been stopped.