### PR TITLE
Fix links to phaser 3 docs in #feedback section

### DIFF
--- a/public/iframe.html
+++ b/public/iframe.html
@@ -38,7 +38,7 @@
         Phaser 3 is still only a few months old and there are Examples which may not work.
         If this is one of them, then we're really sorry! Help us by clicking the 'Open Issue' button, pasting the URL
         of the example, and we'll fix it (or remove it) as soon as we can.<br /><br />
-        Don't forget the <strong>API Docs</strong>. You can view a <a href="https://photonstorm.github.io/phaser3-docs/list_class.html">list of all Classes</a> or the <a href="https://photonstorm.github.io/phaser3-docs/list_namespace.html">Namespaces list</a>.
+        Don't forget the <strong><a href="https://photonstorm.github.io/phaser3-docs/">API Docs</a></strong>. You can view a <a href="https://photonstorm.github.io/phaser3-docs/classes.list.html">list of all Classes</a> or the <a href="https://photonstorm.github.io/phaser3-docs/namespaces.list.html">Namespaces list</a>.
     </p>
 
 </body>

--- a/public/view.html
+++ b/public/view.html
@@ -33,7 +33,7 @@
         Phaser 3 is still only a few months old and there are Examples which may not work.
         If this is one of them, then we're really sorry! Help us by clicking the 'Open Issue' button, pasting the URL
         of the example, and we'll fix it (or remove it) as soon as we can.<br /><br />
-        Don't forget the <strong>API Docs</strong>. You can view a <a href="https://photonstorm.github.io/phaser3-docs/list_class.html">list of all Classes</a> or the <a href="https://photonstorm.github.io/phaser3-docs/list_namespace.html">Namespaces list</a>.
+        Don't forget the <strong><a href="https://photonstorm.github.io/phaser3-docs/">API Docs</a></strong>. You can view a <a href="https://photonstorm.github.io/phaser3-docs/classes.list.html">list of all Classes</a> or the <a href="https://photonstorm.github.io/phaser3-docs/namespaces.list.html">Namespaces list</a>.
     </p>
 
 </body>


### PR DESCRIPTION
- Fix broken links to namespace and class listings
- Add a link to the main page of the docs