### PR TITLE
Fix audio sprites loading

### DIFF
--- a/public/src/audio/HTML5 Audio/AudioSprite.js
+++ b/public/src/audio/HTML5 Audio/AudioSprite.js
@@ -27,12 +27,10 @@ function preload ()
 
     this.load.bitmapFont('nokia', 'assets/fonts/bitmap/nokia16black.png', 'assets/fonts/bitmap/nokia16black.xml');
 
-    this.load.audioSprite('sfx', [
+    this.load.audioSprite('sfx', 'assets/audio/SoundEffects/fx_mixdown.json', [
         'assets/audio/SoundEffects/fx_mixdown.ogg',
         'assets/audio/SoundEffects/fx_mixdown.mp3'
-    ], 'assets/audio/SoundEffects/fx_mixdown.json', {
-        instances: 4
-    });
+    ]);
 }
 
 function create ()


### PR DESCRIPTION
Use the right order of the `load.audioSprite()` method.