### PR TITLE
Fix the method name to load am Impact tilemap

### DIFF
--- a/public/src/game objects/tilemap/collision/weltmeister map and impact.js
+++ b/public/src/game objects/tilemap/collision/weltmeister map and impact.js
@@ -26,7 +26,7 @@ function preload ()
     this.load.image('player', 'assets/sprites/phaser-dude.png');
 
     // A standard Weltmeister map with two layers: "map" & "collision"
-    this.load.tilemapWeltmeister('map', 'assets/tilemaps/maps/impact3.json');
+    this.load.tilemapImpact('map', 'assets/tilemaps/maps/impact3.json');
 }
 
 function create ()


### PR DESCRIPTION
The loader was using the `load.tilemapWeltmeister()` but the rigth method is `load.tilemapImpact()`