### PR TITLE
Fix the load of the Impact tilemap

### DIFF
--- a/public/src/physics/impact/slope tests.js
+++ b/public/src/physics/impact/slope tests.js
@@ -26,7 +26,7 @@ function preload ()
     this.load.image('player', 'assets/sprites/phaser-dude.png');
 
     // A standard Weltmeister map with two layers: "map" & "collision"
-    this.load.tilemapWeltmeister('map', 'assets/tilemaps/maps/impact3.json');
+    this.load.tilemapImpact('map', 'assets/tilemaps/maps/impact3.json');
 }
 
 function create ()


### PR DESCRIPTION
Use the right method to load an Impact tilemap: `load.tilemapImpact()`.