### PR TITLE
Camera ignore examples, update rendertexture examples

### DIFF
--- a/public/src/camera/camera filter.js
+++ b/public/src/camera/camera filter.js
@@ -1,0 +1,68 @@
+var config = {
+    type: Phaser.AUTO,
+    parent: 'phaser-example',
+    width: 800,
+    height: 600,
+    scene: {
+        preload: preload,
+        create: create,
+        update: update
+    }
+};
+
+var camlist;
+
+var UI_CAM_1;
+var UI_CAM_2;
+
+var image;
+var UIText1;
+var UIText2;
+var UIText3;
+
+var game = new Phaser.Game(config);
+
+function preload() {
+    this.load.image('einstein', 'assets/pics/ra-einstein.png');
+}
+
+function create() {
+    image = this.add.image(400, 300, 'einstein');
+
+    UIText1 = this.add.text(0, 32, '0');
+    UIText2 = this.add.text(0, 64, '0');
+    UIText3 = this.add.text(500, 64, '0');
+
+    UI_CAM_1 = this.cameras.add();
+    UI_CAM_2 = this.cameras.add();
+
+    //list of all cameras
+    camlist = this.cameras.cameras;
+
+    //exclude gameobject to some camera
+    UIText1.cameraFilter = setCamera(UI_CAM_1);
+    UIText2.cameraFilter = setCamera(UI_CAM_1);
+    UIText3.cameraFilter = setCamera(UI_CAM_2);
+
+    image.cameraFilter = setCamera(this.cameras.main);
+
+}
+
+function update() {
+    UIText1.setText("UI Camera 1");
+    UIText2.setText("Main camera rotation: " + this.cameras.main.rotation);
+    UIText3.setText("UI Camera 2");
+
+    UI_CAM_1.scrollY = Math.sin(this.time.now / 100) * 10;
+    UI_CAM_2.scrollX = Math.sin(this.time.now / 100) * 10;
+
+    this.cameras.main.setZoom(Math.abs(Math.sin(this.cameras.main.rotation)) * 0.5 + 1);
+    this.cameras.main.rotation += 0.01;
+}
+
+function setCamera(cam) {
+
+    let l = (1 << camlist.length) - 1;
+
+    return l & ~cam.id;
+}

--- a/public/src/camera/ignore container.js
+++ b/public/src/camera/ignore container.js
@@ -1,0 +1,54 @@
+var config = {
+    type: Phaser.AUTO,
+    parent: 'phaser-example',
+    width: 800,
+    height: 600,
+    scene: {
+        preload: preload,
+        create: create,
+        update: update
+    }
+};
+
+var image;
+var cont;
+var UICam;
+var UIText1;
+var UIText2;
+
+var game = new Phaser.Game(config);
+
+function preload() {
+    this.load.image('einstein', 'assets/pics/ra-einstein.png');
+}
+
+function create() {
+    image = this.add.image(400, 300, 'einstein');
+
+    UIText1 = this.add.text(0, 32, '0');
+    UIText2 = this.add.text(0, 64, '0');
+
+    cont = this.add.container();
+
+    cont.add([UIText1, UIText2]);
+
+    //  Add in a new camera, the same size and position as the main camera
+    UICam = this.cameras.add(0, 0, 800, 600);
+
+    //  The main camera will not render the container
+    this.cameras.main.ignore(cont);
+
+    //  The new UI Camera will not render the background image
+    UICam.ignore(image);
+}
+
+function update() {
+    UIText1.setText("Main camera rotation: " + this.cameras.main.rotation);
+    UIText2.setText("Main camera zoom: " + this.cameras.main.zoom);
+
+    //wobble the container
+    cont.y = Math.sin(this.time.now / 100) * 10;
+
+    this.cameras.main.setZoom(Math.abs(Math.sin(this.cameras.main.rotation)) * 0.5 + 1);
+    this.cameras.main.rotation += 0.01;
+}

--- a/public/src/camera/ignore group children.js
+++ b/public/src/camera/ignore group children.js
@@ -1,0 +1,67 @@
+var config = {
+    type: Phaser.AUTO,
+    parent: 'phaser-example',
+    width: 800,
+    height: 600,
+    scene: {
+        preload: preload,
+        create: create,
+        update: update
+    }
+};
+
+var image;
+var cont1;
+var cont2;
+var group;
+
+var UIText1;
+var UIText2;
+var UIText3;
+
+var UICam;
+
+var game = new Phaser.Game(config);
+
+function preload() {
+    this.load.image('einstein', 'assets/pics/ra-einstein.png');
+}
+
+function create() {
+    image = this.add.image(400, 300, 'einstein');
+
+    UIText1 = this.add.text(0, 32, '0');
+    UIText2 = this.add.text(0, 64, '0');
+    UIText3 = this.add.text(540, 64, '3');
+
+    cont1 = this.add.container();
+    cont2 = this.add.container();
+
+    cont1.add(UIText1);
+    cont1.add(UIText2);
+    cont2.add(UIText3);
+
+    group = this.add.group();
+    group.add(cont1);
+    group.add(cont2);
+    //  Add in a new camera, the same size and position as the main camera
+    UICam = this.cameras.add(0, 0, 800, 600);
+
+    //  The main camera will not render the children
+    this.cameras.main.ignore(group.getChildren());
+
+    //  The new UI Camera will not render the background image
+    UICam.ignore(image);
+}
+
+function update() {
+    UIText1.setText("Main camera rotation: " + this.cameras.main.rotation);
+    UIText2.setText("Main camera zoom: " + this.cameras.main.zoom);
+    UIText3.setText("lol: " + cont2.y);
+
+    //wobble the container
+    cont2.y = Math.sin(this.time.now / 100) * 10;
+
+    this.cameras.main.setZoom(Math.abs(Math.sin(this.cameras.main.rotation)) * 0.5 + 1);
+    this.cameras.main.rotation += 0.01;
+}

--- a/public/src/game objects/render texture/brute force.js
+++ b/public/src/game objects/render texture/brute force.js
@@ -13,7 +13,7 @@ var config = {
 var game = new Phaser.Game(config);
 
 var rt;
-var matrixTexture;
+var rnd;
 var t;
 
 function preload()
@@ -25,9 +25,9 @@ function preload()
 
 function create()
 {
-    matrixTexture = this.textures.get('matrix');
+    rt = this.make.renderTexture({ x: 0, y: 0, width: 800, height: 600 });
 
-    rt = this.make.renderTexture({ x: 0, y: 0, width: 800, height: 600 }).setOrigin(0, 0);
+    rnd = Math.random;
 }
 
 function update()
@@ -45,17 +45,9 @@ function update()
 
 function draw()
 {
-    rt.save();
+    var alpha = rnd();
+    var tint = (0x00ffff * (rnd() * 0.1 + 0.8));
+    var frame = ~~(rnd() * 22);
 
-    rt.globalAlpha = Math.random();
-    rt.globalTint = (0x00ffff * (Math.random() * 0.1 + 0.9));
-
-    var frame = matrixTexture.frames[Math.floor(Math.random() * 10)];
-
-    var rand = Math.random() + 0.1;
-
-    rt.currentMatrix = [rand, 0, 0, rand, Math.random() * 800, Math.random() * 600];
-
-    rt.draw(matrixTexture, frame, -matrixTexture.frames[0].halfWidth, -matrixTexture.frames[0].halfHeight);
-    rt.restore();
+    rt.drawFrame("matrix", frame, rnd() * 800, rnd() * 600, alpha, tint);
 }

--- a/public/src/game objects/render texture/explosion.js
+++ b/public/src/game objects/render texture/explosion.js
@@ -13,7 +13,7 @@ var game = new Phaser.Game(config);
 
 var rt;
 var blast;
-var nuke;
+var nukeFX;
 
 function preload() 
 {
@@ -23,69 +23,48 @@ function preload()
 
 function create() 
 {
-    rt = this.make.renderTexture({ x: 0, y: 0, width: 800, height: 600 }).setOrigin(0, 0);
+    rt = this.make.renderTexture({ x: 0, y: 0, width: 800, height: 600 });
 
     blast = this.add.follower(null, 50, 350, 'smoke');
-
-    nuke = this.tweens.add({
-        targets: blast,
-        scaleX: 8,
-        scaleY: 8,
-        alpha: 0,
-        duration: 1000,
-        ease: "Bounce.easeIn",
-        onComplete: function () { rt.clear(); blast.alpha = 0 },
-        paused: true
-    });
-
-    nuke.setCallback('onUpdate', draw, [], this);
-
-    this.input.on('pointerdown', function (pointer)
-    {
-
-        explode(pointer.x, pointer.y);
-
-    }, this);
-}
-
-function explode(x, y) 
-{
-    blast.x = x;
-    blast.y = y;
-    blast.setScale(0.5);
-    blast.alpha = 1;
 
     var curve = new Phaser.Curves.Spline([200, 500, 600, 500, 625, 475, 200, 500, 400, 500, 400, 250]);
 
     blast.setPath(curve);
+
+    nukeFX = this.tweens.add({
+        targets: blast,
+        scaleX: 8,
+        scaleY: 8,
+        alpha: 0,
+        duration: 1500,
+        ease: "Bounce.easeInOut",
+        onComplete: function () { rt.clear(); blast.alpha = 0 },
+        paused: true
+    });
+
+    nukeFX.setCallback('onUpdate', draw, [], this);
+
+    this.input.on('pointerdown', function (pointer)
+    {
+        detonate(pointer.x, pointer.y);
+
+    }, this);
+}
+
+function detonate(x, y) 
+{
+    blast.setPosition(x, y).setScale(1).setAlpha(1);
+
     blast.startFollow(200);
 
-    nuke.play();
+    nukeFX.restart();
 }
 
 function draw() 
 {
-    rt.save();
+    blast.setRotation(Math.random() * 4 -2);
 
-    var crot = Math.cos(blast.rotation + Math.random() * 2);
-    var srot = Math.sin(blast.rotation + Math.random() * 2);
+    blast.setTexture(Math.random() < 0.8 ? 'fire' : 'smoke');
 
-    var rand = Math.random() * 2;
-
-    var sx = blast.scaleX + rand;
-    var sy = blast.scaleY + rand;
-
-    if (Math.random() < 0.8)
-    {
-        blast.setTexture('fire');
-    } else
-    {
-        blast.setTexture('smoke');
-    }
-
-    rt.currentMatrix = [crot * sx, srot, -srot, crot * sy, blast.x, blast.y];
-
-    rt.setAlpha(blast.alpha);
-    rt.draw(blast.texture, blast.frame, -blast.width / 2, -blast.height / 2);
-    rt.restore();
+    rt.draw(blast);
 }

--- a/public/src/game objects/render texture/fireball.js
+++ b/public/src/game objects/render texture/fireball.js
@@ -12,8 +12,8 @@ var config = {
 var game = new Phaser.Game(config);
 
 var rt;
-var ball1;
-var fireblast;
+var fireball;
+var fireFX;
 
 function preload()
 {
@@ -23,24 +23,24 @@ function preload()
 
 function create()
 {
-    rt = this.make.renderTexture({ x: 0, y: 0, width: 800, height: 600 }).setOrigin(0, 0);
+    rt = this.make.renderTexture({ x: 0, y: 0, width: 800, height: 600 });
 
     player = this.add.image(100, 300, 'dude');
 
-    ball1 = this.add.follower(null, 50, 350, 'fire');
+    fireball = this.add.follower(null, 50, 350, 'fire');
 
-    fireblast = this.tweens.add({
-        targets: ball1,
+    fireFX = this.tweens.add({
+        targets: fireball,
         scaleX: 3,
         scaleY: 3,        
         alpha: 0,
         duration: 300,
-        ease: "Cubic.easeInOut",
-        onComplete: function () { rt.clear(); ball1.alpha = 0 },
+        ease: "Cubic.easeOut",
+        onComplete: function () { rt.clear(); fireball.alpha = 0 },
         paused: true
     });
 
-    fireblast.setCallback('onUpdate', draw, [], this);
+    fireFX.setCallback('onUpdate', draw, [], this);
 
     this.input.on('pointerdown', function (pointer)
     {
@@ -50,32 +50,17 @@ function create()
 
 function generate(x, y)
 {
-    ball1.x = player.x;
-    ball1.y = player.y;
-    ball1.setScale(0.5);
-    ball1.alpha = 1;
+    fireball.setPosition(player.x, player.y).setScale(0.5).setAlpha(1);
 
     curve = new Phaser.Curves.Line(new Phaser.Math.Vector2(player.x, player.y), new Phaser.Math.Vector2(x, y));
 
-    ball1.setPath(curve);
-    ball1.startFollow(300);
+    fireball.setPath(curve);
+    fireball.startFollow(300);
     
-    fireblast.play();    
+    fireFX.restart();    
 }
 
 function draw()
 {
-    rt.save();
-
-    var crot = Math.cos(ball1.rotation + Math.random());
-    var srot = Math.sin(ball1.rotation + Math.random());
-
-    var sx = ball1.scaleX + Math.random();
-    var sy = ball1.scaleY + Math.random();
-
-    rt.currentMatrix = [crot * sx, srot, -srot, crot * sy, ball1.x, ball1.y];
-
-    rt.alpha = ball1.alpha;
-    rt.draw(ball1.texture, ball1.frame, -ball1.width / 2, -ball1.height / 2);
-    rt.restore();
+    rt.draw(fireball);
 }

--- a/public/src/game objects/render texture/sparks.js
+++ b/public/src/game objects/render texture/sparks.js
@@ -13,6 +13,7 @@ var config = {
 var game = new Phaser.Game(config);
 
 var rt;
+var rnd;
 var player;
 
 function preload() 
@@ -24,14 +25,14 @@ function create()
 {
     rt = this.make.renderTexture({ x: 0, y: 0, width: 800, height: 600 });
 
-    player = this.add.sprite(256, 256, 'dude');
-    player.setOrigin(0.5, 0.5);
+    player = this.add.sprite(256, 256, 'dude').setOrigin(0.5, 0.5);
+
+    rnd = Math.random;
 }
 
 function update()
 {
-    player.x = this.input.x;
-    player.y = this.input.y;
+    player.setPosition(this.input.x, this.input.y);
 
     draw();
 }
@@ -39,15 +40,17 @@ function update()
 function draw() 
 {
     rt.clear();
-    rt.globalAlpha = Math.random();
-    rt.globalTint = ((0.5 + Math.random()) * 0xFFFFFF << 0);
+    
+    rt.alpha = rnd();
+    rt.tint = (0xFFFFFF << rnd()*8092);
 
     for (i = 0; i < 5; i++)
     {
-        var rot = Math.floor((Math.random() * Math.PI * 2) + 1);
-        var dist = 75 + Math.floor((Math.random() * 50) + 1);
-
-        rt.draw(player.texture, player.frame, player.x + dist * Math.cos(rot), player.y + dist * Math.sin(rot));
-        rt.restore();
+        var rot = Math.floor((rnd() * Math.PI * 2) + 1);
+        var dist = 75 + Math.floor((rnd() * 50) + 1);
+        var x = player.x + dist * Math.cos(rot);
+        var y = player.y + dist * Math.sin(rot);
+        
+        rt.draw("dude", x, y);
     }
 }

--- a/public/src/game objects/render texture/trail2.js
+++ b/public/src/game objects/render texture/trail2.js
@@ -22,7 +22,7 @@ function preload()
 
 function create() 
 {
-    rt = this.make.renderTexture({ x: 0, y: 0, width: 800, height: 600 }).setOrigin(0, 0);
+    rt = this.make.renderTexture({ x: 0, y: 0, width: 800, height: 600 });
 
     player = this.add.image(256, 256, 'dude');
     player.setOrigin(0.5, 0.5);
@@ -30,16 +30,8 @@ function create()
 
 function update()
 {
-    player.x = this.input.x;
-    player.y = this.input.y;
+    player.setPosition(this.input.x, this.input.y);
 
-    draw();
+    rt.draw(player);
 }
 
-function draw() 
-{
-    rt.save();
-    rt.translate(player.x, player.y);
-    rt.draw(player.texture, player.frame, -player.width / 2, -player.height / 2);
-    rt.restore();
-}


### PR DESCRIPTION
Mainly to test photonstorm/phaser#3889, seems to work in dev builds, also one example using cameraFilter.

[ignore container](http://jsfiddle.net/pg6w2z1c/)
[camera filter](http://jsfiddle.net/jr6g03s8/)
[ignore group children](http://jsfiddle.net/7j2xr4cn/)


Rendertexture examples updates to match API changes.

Note :


rt.drawFrame() seems to work with passing alpha and tint, but I could not do the same for rt.draw() yet in dev build. I can always update according to API later on... 