### PR TITLE
Fix Invaders demo so it ends when last enemy killed

### DIFF
--- a/public/src/scenes/multi demo/Invaders.js
+++ b/public/src/scenes/multi demo/Invaders.js
@@ -105,6 +105,11 @@ class Invaders extends Phaser.Scene {
             }
         }
 
+        if (this.topLeft === null && this.bottomRight === null)
+        {
+            this.gameOver();
+        }
+
         this.topLeft = first;
         this.bottomRight = last;
     }
@@ -187,7 +192,7 @@ class Invaders extends Phaser.Scene {
 
     update ()
     {
-        if (this.isGameOver)
+        if (this.isGameOver || (this.bottomRight === null && this.topLeft === null))
         {
             return;
         }


### PR DESCRIPTION
When the last enemy is killed it causes the game to throw an error due to the update method checking the body of now null enemy checks.

This adds a check to make sure that if the top left and bottom right enemies are null the game is considered over.