### PR TITLE
Optimized screenshot generation and added script to package.json

### DIFF
--- a/generate-screenshots.js
+++ b/generate-screenshots.js
@@ -9,7 +9,7 @@ server.listen(8080, 'localhost', () => {});
 
 let examples = [];
 const getExamples = (path, depth = 0) => {
-  const files = fs.readdirSync(path);
+  const files = fs.readdirSync(p.resolve(path));
   if (depth > maxDepth || path.includes('archived')) {
     return;
   }
@@ -44,7 +44,7 @@ const getScreenshots = (path, depth = 0) => {
   for(let file of files) {
     const fileInfo = fs.statSync(p.resolve(path, file));
     if (fileInfo.isDirectory()) {
-      getScreenshots(p.resolve(path,file), depth + 1);
+      getScreenshots(p.resolve(path, file), depth + 1);
     } 
     screenshots.push(p.resolve(path, file));
   }
@@ -74,7 +74,7 @@ const saveCanvas = async (page, example) => {
         timeout: 5000,
       });
     } catch (e) {
-      fs.copyFileSync(p.resolve(public/images/doc.png), p.resolve(path));
+      fs.copyFileSync(p.resolve('public/images/doc.png'), p.resolve(path));
       resolve();
       return;
     }

--- a/generate-screenshots.js
+++ b/generate-screenshots.js
@@ -62,11 +62,11 @@ screenshots = screenshots
 
 const saveCanvas = async (page, example) => {
   return new Promise(async (resolve, reject) => {
-    const path = example.path ;
+    const path = example.path;
 
     console.log('- ' + example.url);
     console.log('  Screenshot to path:', path);
-    const filename = path.match(/[^\/]+$/)[0];
+    const filename = path.match(/[^\/\\]+$/)[0];
     fs.mkdirp(path.slice(0, -(filename.length + 1)));
     await page.goto(example.url);
     try {
@@ -74,7 +74,7 @@ const saveCanvas = async (page, example) => {
         timeout: 5000,
       });
     } catch (e) {
-      fs.copyFileSync('public/images/doc.png', path);
+      fs.copyFileSync(p.resolve(public/images/doc.png), p.resolve(path));
       resolve();
       return;
     }
@@ -88,11 +88,11 @@ const saveCanvas = async (page, example) => {
     const canvas = await page.$('canvas');
     if (canvas) {
       await canvas.screenshot({
-        path,
+        path: p.resolve(path),
       });
     }
     else {
-      fs.copyFileSync('public/images/doc.png', path);
+      fs.copyFileSync(p.resolve(public/images/doc.png), p.resolve(path));
     }
     resolve();
   });

--- a/generate-screenshots.js
+++ b/generate-screenshots.js
@@ -1,6 +1,11 @@
 const puppeteer = require('puppeteer');
+const httpServer = require('http-server');
 const fs = require('fs-extra');
 const p = require('path');
+
+
+var server = httpServer.createServer();
+server.listen(8080, 'localhost', () => {});
 
 let examples = [];
 const getExamples = (path, depth = 0) => {
@@ -59,10 +64,10 @@ const saveCanvas = async (page, example) => {
   return new Promise(async (resolve, reject) => {
     const path = example.path ;
 
-    console.log('  screenshot to path:', path);
+    console.log('- ' + example.url);
+    console.log('  Screenshot to path:', path);
     const filename = path.match(/[^\/]+$/)[0];
     fs.mkdirp(path.slice(0, -(filename.length + 1)));
-    console.log(example.url)
     await page.goto(example.url);
     try {
       await page.waitForSelector('canvas', {
@@ -103,6 +108,7 @@ async function run() {
   }
 
   browser.close();
+  server.close();
 }
 
 run();

--- a/generate-screenshots.js
+++ b/generate-screenshots.js
@@ -92,7 +92,7 @@ const saveCanvas = async (page, example) => {
       });
     }
     else {
-      fs.copyFileSync(p.resolve(public/images/doc.png), p.resolve(path));
+      fs.copyFileSync(p.resolve('public/images/doc.png'), p.resolve(path));
     }
     resolve();
   });

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "./node_modules/.bin/http-server -s -o",
     "update": "node ./build.js",
+    "screenshots": "node ./generate-screenshots.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/scan-for-error.js
+++ b/scan-for-error.js
@@ -1,0 +1,108 @@
+const puppeteer = require('puppeteer');
+const httpServer = require('http-server');
+const fs = require('fs-extra');
+const p = require('path');
+
+
+const maxDepth = 25;
+var server = httpServer.createServer();
+server.listen(8080, 'localhost', () => {});
+
+let examples = [];
+const getExamples = (path, depth = 0) => {
+  const files = fs.readdirSync(p.resolve(path));
+  if (depth > maxDepth || path.includes('archived')) {
+    return;
+  }
+  
+  if (files.includes('boot.json')){
+    examples.push({
+      url: path + '/' + 'boot.json',
+      path: p.resolve(path, 'boot.json'),
+    });
+  } else {
+    for(let file of files) {
+      const fileInfo = fs.statSync(p.resolve(path, file));
+      if (fileInfo.isDirectory() && file[0] !== '_') {
+        getExamples(path + '/' + file, depth + 1);
+      } else if (file[0] !== '_' && file[0] !== '.') {
+        examples.push({
+          url: path + '/' +  file,
+          path: p.resolve(path, file),
+        });
+      }
+    }
+  }
+}
+
+
+getExamples('./public/src');
+examples = examples
+  .filter(e => !e.url.includes('rbush'))
+  .filter(e => e.url.match(/[^\.]+$/)[0].slice(0,2) === 'js')
+  .map(e => ({ url: e.url = 'http://localhost:8080/' + (e.url.includes('boot.json') ? 'boot.html?src=' : 'view.html?src=') + e.url.slice(9).replace(/\//g, '\\'), path: e.path.toLowerCase() }));
+
+
+const scanForError = async (page, example) => {
+  return new Promise(async (resolve, reject) => {
+    const path = example.path;
+
+    const filename = path.match(/[^\/\\]+$/)[0];
+    fs.mkdirp(path.slice(0, -(filename.length + 1)));
+
+    const logError = (e) => {
+      console.log('- ' + example.url);
+      console.log('  .' + example.path.slice(__dirname.length));
+      console.log('');
+      console.log('  Script', e.toString().split('\n')[0], '\n\n\n');
+    };
+    page.on('error', logError);
+    page.on('pageerror', logError);
+
+    await page.goto(example.url);
+
+    try {
+      await page.waitForSelector('canvas', {
+        timeout: 3000,
+      });
+    } catch (e) {
+      console.log('- ' + example.url);
+      console.log('  .' + example.path.slice(__dirname.length));
+      console.log('');
+      console.log('  No canvas on load:', e.toString().split('\n')[0],  '\n\n\n');
+      page.removeListener('error', logError);
+      page.removeListener('pageerror', logError);
+      resolve();
+      return;
+    }
+    await page.waitFor(500);
+    page.mouse.click(200, 150);
+    await page.waitFor(500);
+    const canvas = await page.$('canvas');
+    if (!canvas) {
+      console.log('- ' + example.url);
+      console.log('  .' + example.path.slice(__dirname.length));
+      console.log('');
+      console.log('  No canvas after click\n\n\n');
+    }
+    page.removeListener('error', logError);
+    page.removeListener('pageerror', logError);
+    resolve();
+  });
+};
+
+
+async function run() {
+  const browser = await puppeteer.launch({ headless: true });
+  const [page] = await browser.pages();
+  page.setUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1');
+
+  for (let example of examples) {
+    await scanForError(page, example);
+  }
+
+  browser.close();
+  server.close();
+}
+
+run();


### PR DESCRIPTION
Optimizations:
- Screenshots are a bit quicker since it now scans `src-dir` instead of scanning the actual page.
  - Excluding files/dirs starting with `_` and `.`
- Sceenshot-generation will only run for the scripts that are lacking screenshots
- Starts http-server on localhost by itself

Also added script in package.json - `npm run screenshots`

Note that you have to remove a screenshot for anything to happen :-)