### PR TITLE
Fixed more occurances of #203 - Fix audio sprites loading

### DIFF
--- a/public/src/audio/HTML5 Audio/Basic Playback and Events.js
+++ b/public/src/audio/HTML5 Audio/Basic Playback and Events.js
@@ -40,10 +40,10 @@ function preload ()
         instances: 2
     });
 
-    this.load.audioSprite('creatures', [
+    this.load.audioSprite('creatures', 'assets/audio/Ludwig van Beethoven - The Creatures of Prometheus, Op. 43/sprites.json', [
         'assets/audio/Ludwig van Beethoven - The Creatures of Prometheus, Op. 43/sprites.ogg',
         'assets/audio/Ludwig van Beethoven - The Creatures of Prometheus, Op. 43/sprites.mp3'
-    ], 'assets/audio/Ludwig van Beethoven - The Creatures of Prometheus, Op. 43/sprites.json');
+    ]);
 }
 
 var first;

--- a/public/src/audio/No Audio/Basic Playback and Events.js
+++ b/public/src/audio/No Audio/Basic Playback and Events.js
@@ -38,10 +38,10 @@ function preload ()
         'assets/audio/Ludwig van Beethoven - The Creatures of Prometheus, Op. 43/Overture.mp3'
     ]);
 
-    this.load.audioSprite('creatures', [
+    this.load.audioSprite('creatures', 'assets/audio/Ludwig van Beethoven - The Creatures of Prometheus, Op. 43/sprites.json', [
         'assets/audio/Ludwig van Beethoven - The Creatures of Prometheus, Op. 43/sprites.ogg',
         'assets/audio/Ludwig van Beethoven - The Creatures of Prometheus, Op. 43/sprites.mp3'
-    ], 'assets/audio/Ludwig van Beethoven - The Creatures of Prometheus, Op. 43/sprites.json');
+    ]);
 }
 
 var first;

--- a/public/src/audio/Web Audio/Basic Playback and Events.js
+++ b/public/src/audio/Web Audio/Basic Playback and Events.js
@@ -35,10 +35,10 @@ function preload ()
         'assets/audio/Ludwig van Beethoven - The Creatures of Prometheus, Op. 43/Overture.mp3'
     ]);
 
-    this.load.audioSprite('creatures', [
+    this.load.audioSprite('creatures', 'assets/audio/Ludwig van Beethoven - The Creatures of Prometheus, Op. 43/sprites.json', [
         'assets/audio/Ludwig van Beethoven - The Creatures of Prometheus, Op. 43/sprites.ogg',
         'assets/audio/Ludwig van Beethoven - The Creatures of Prometheus, Op. 43/sprites.mp3'
-    ], 'assets/audio/Ludwig van Beethoven - The Creatures of Prometheus, Op. 43/sprites.json');
+    ]);
 }
 
 var first;


### PR DESCRIPTION
Changes to be committed:
modified:   public/src/audio/HTML5 Audio/Basic Playback and Events.js
modified:   public/src/audio/No Audio/Basic Playback and Events.js
modified:   public/src/audio/Web Audio/Basic Playback and Events.js
	    Re-ordered parameters in call to load.audioSprite()