### PR TITLE
fixed backslash to forward slash

### DIFF
--- a/public/examples.json
+++ b/public/examples.json
@@ -3,155 +3,155 @@
   "name": "src",
   "children": [
     {
-      "path": "src\\actions",
+      "path": "src/actions",
       "name": "actions",
       "children": [
         {
-          "path": "src\\actions\\grid align.js",
+          "path": "src/actions/grid align.js",
           "name": "grid align.js",
           "size": 744,
           "extension": ".js"
         },
         {
-          "path": "src\\actions\\inc x layers.js",
+          "path": "src/actions/inc x layers.js",
           "name": "inc x layers.js",
           "size": 1323,
           "extension": ".js"
         },
         {
-          "path": "src\\actions\\place on a circle multi.js",
+          "path": "src/actions/place on a circle multi.js",
           "name": "place on a circle multi.js",
           "size": 1009,
           "extension": ".js"
         },
         {
-          "path": "src\\actions\\place on a circle reversed.js",
+          "path": "src/actions/place on a circle reversed.js",
           "name": "place on a circle reversed.js",
           "size": 1671,
           "extension": ".js"
         },
         {
-          "path": "src\\actions\\place on circle.js",
+          "path": "src/actions/place on circle.js",
           "name": "place on circle.js",
           "size": 955,
           "extension": ".js"
         },
         {
-          "path": "src\\actions\\place on ellipse.js",
+          "path": "src/actions/place on ellipse.js",
           "name": "place on ellipse.js",
           "size": 940,
           "extension": ".js"
         },
         {
-          "path": "src\\actions\\place on line.js",
+          "path": "src/actions/place on line.js",
           "name": "place on line.js",
           "size": 564,
           "extension": ".js"
         },
         {
-          "path": "src\\actions\\place on part of a circle.js",
+          "path": "src/actions/place on part of a circle.js",
           "name": "place on part of a circle.js",
           "size": 1484,
           "extension": ".js"
         },
         {
-          "path": "src\\actions\\place on rectangle shift.js",
+          "path": "src/actions/place on rectangle shift.js",
           "name": "place on rectangle shift.js",
           "size": 1028,
           "extension": ".js"
         },
         {
-          "path": "src\\actions\\place on rectangle.js",
+          "path": "src/actions/place on rectangle.js",
           "name": "place on rectangle.js",
           "size": 574,
           "extension": ".js"
         },
         {
-          "path": "src\\actions\\place on triangle.js",
+          "path": "src/actions/place on triangle.js",
           "name": "place on triangle.js",
           "size": 635,
           "extension": ".js"
         },
         {
-          "path": "src\\actions\\random circle.js",
+          "path": "src/actions/random circle.js",
           "name": "random circle.js",
           "size": 678,
           "extension": ".js"
         },
         {
-          "path": "src\\actions\\random ellipse.js",
+          "path": "src/actions/random ellipse.js",
           "name": "random ellipse.js",
           "size": 688,
           "extension": ".js"
         },
         {
-          "path": "src\\actions\\random line.js",
+          "path": "src/actions/random line.js",
           "name": "random line.js",
           "size": 612,
           "extension": ".js"
         },
         {
-          "path": "src\\actions\\random rectangle.js",
+          "path": "src/actions/random rectangle.js",
           "name": "random rectangle.js",
           "size": 688,
           "extension": ".js"
         },
         {
-          "path": "src\\actions\\random triangle.js",
+          "path": "src/actions/random triangle.js",
           "name": "random triangle.js",
           "size": 785,
           "extension": ".js"
         },
         {
-          "path": "src\\actions\\rotate around distance.js",
+          "path": "src/actions/rotate around distance.js",
           "name": "rotate around distance.js",
           "size": 661,
           "extension": ".js"
         },
         {
-          "path": "src\\actions\\rotate around xy.js",
+          "path": "src/actions/rotate around xy.js",
           "name": "rotate around xy.js",
           "size": 937,
           "extension": ".js"
         },
         {
-          "path": "src\\actions\\rotate around.js",
+          "path": "src/actions/rotate around.js",
           "name": "rotate around.js",
           "size": 778,
           "extension": ".js"
         },
         {
-          "path": "src\\actions\\set alpha.js",
+          "path": "src/actions/set alpha.js",
           "name": "set alpha.js",
           "size": 609,
           "extension": ".js"
         },
         {
-          "path": "src\\actions\\set xy.js",
+          "path": "src/actions/set xy.js",
           "name": "set xy.js",
           "size": 737,
           "extension": ".js"
         },
         {
-          "path": "src\\actions\\shift position.js",
+          "path": "src/actions/shift position.js",
           "name": "shift position.js",
           "size": 881,
           "extension": ".js"
         },
         {
-          "path": "src\\actions\\spread.js",
+          "path": "src/actions/spread.js",
           "name": "spread.js",
           "size": 666,
           "extension": ".js"
         },
         {
-          "path": "src\\actions\\wrap in camera bounds.js",
+          "path": "src/actions/wrap in camera bounds.js",
           "name": "wrap in camera bounds.js",
           "size": 1085,
           "extension": ".js"
         },
         {
-          "path": "src\\actions\\wrap in rectangle.js",
+          "path": "src/actions/wrap in rectangle.js",
           "name": "wrap in rectangle.js",
           "size": 782,
           "extension": ".js"
@@ -160,233 +160,233 @@
       "size": 21514
     },
     {
-      "path": "src\\animation",
+      "path": "src/animation",
       "name": "animation",
       "children": [
         {
-          "path": "src\\animation\\add animation event.js",
+          "path": "src/animation/add animation event.js",
           "name": "add animation event.js",
           "size": 1709,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\add frames to existing animation.js",
+          "path": "src/animation/add frames to existing animation.js",
           "name": "add frames to existing animation.js",
           "size": 1018,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\all frames texture atlas animation.js",
+          "path": "src/animation/all frames texture atlas animation.js",
           "name": "all frames texture atlas animation.js",
           "size": 575,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\animation data.js",
+          "path": "src/animation/animation data.js",
           "name": "animation data.js",
           "size": 2100,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\animation from png sequence.js",
+          "path": "src/animation/animation from png sequence.js",
           "name": "animation from png sequence.js",
           "size": 1169,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\animation progress.js",
+          "path": "src/animation/animation progress.js",
           "name": "animation progress.js",
           "size": 971,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\animation repeat event.js",
+          "path": "src/animation/animation repeat event.js",
           "name": "animation repeat event.js",
           "size": 1377,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\callback parameters.js",
+          "path": "src/animation/callback parameters.js",
           "name": "callback parameters.js",
           "size": 1292,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\chained animation.js",
+          "path": "src/animation/chained animation.js",
           "name": "chained animation.js",
           "size": 919,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\create animation from canvas texture.js",
+          "path": "src/animation/create animation from canvas texture.js",
           "name": "create animation from canvas texture.js",
           "size": 2270,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\create animation without frame names.js",
+          "path": "src/animation/create animation without frame names.js",
           "name": "create animation without frame names.js",
           "size": 754,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\create from sprite config.js",
+          "path": "src/animation/create from sprite config.js",
           "name": "create from sprite config.js",
           "size": 1740,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\cubes.js",
+          "path": "src/animation/cubes.js",
           "name": "cubes.js",
           "size": 1601,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\export json.js",
+          "path": "src/animation/export json.js",
           "name": "export json.js",
           "size": 1776,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\from animation json.js",
+          "path": "src/animation/from animation json.js",
           "name": "from animation json.js",
           "size": 661,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\from json.js",
+          "path": "src/animation/from json.js",
           "name": "from json.js",
           "size": 740,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\gems.js",
+          "path": "src/animation/gems.js",
           "name": "gems.js",
           "size": 1194,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\generate frames.js",
+          "path": "src/animation/generate frames.js",
           "name": "generate frames.js",
           "size": 690,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\gif to animation.js",
+          "path": "src/animation/gif to animation.js",
           "name": "gif to animation.js",
           "size": 1566,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\hide on complete.js",
+          "path": "src/animation/hide on complete.js",
           "name": "hide on complete.js",
           "size": 824,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\lazer.js",
+          "path": "src/animation/lazer.js",
           "name": "lazer.js",
           "size": 961,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\multi atlas animation.js",
+          "path": "src/animation/multi atlas animation.js",
           "name": "multi atlas animation.js",
           "size": 608,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\multiple sprite sheets.js",
+          "path": "src/animation/multiple sprite sheets.js",
           "name": "multiple sprite sheets.js",
           "size": 910,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\muybridge.js",
+          "path": "src/animation/muybridge.js",
           "name": "muybridge.js",
           "size": 937,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\on complete callback.js",
+          "path": "src/animation/on complete callback.js",
           "name": "on complete callback.js",
           "size": 997,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\on repeat callback.js",
+          "path": "src/animation/on repeat callback.js",
           "name": "on repeat callback.js",
           "size": 924,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\on start callback.js",
+          "path": "src/animation/on start callback.js",
           "name": "on start callback.js",
           "size": 1112,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\on update callback.js",
+          "path": "src/animation/on update callback.js",
           "name": "on update callback.js",
           "size": 1070,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\pause all animations.js",
+          "path": "src/animation/pause all animations.js",
           "name": "pause all animations.js",
           "size": 1450,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\pause animation instances.js",
+          "path": "src/animation/pause animation instances.js",
           "name": "pause animation instances.js",
           "size": 1661,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\remove animation event.js",
+          "path": "src/animation/remove animation event.js",
           "name": "remove animation event.js",
           "size": 1334,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\reverse animation.js",
+          "path": "src/animation/reverse animation.js",
           "name": "reverse animation.js",
           "size": 2498,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\scaled animation.js",
+          "path": "src/animation/scaled animation.js",
           "name": "scaled animation.js",
           "size": 624,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\show on start.js",
+          "path": "src/animation/show on start.js",
           "name": "show on start.js",
           "size": 860,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\single sprite sheet.js",
+          "path": "src/animation/single sprite sheet.js",
           "name": "single sprite sheet.js",
           "size": 688,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\stagger play.js",
+          "path": "src/animation/stagger play.js",
           "name": "stagger play.js",
           "size": 907,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\texture atlas animation.js",
+          "path": "src/animation/texture atlas animation.js",
           "name": "texture atlas animation.js",
           "size": 2221,
           "extension": ".js"
         },
         {
-          "path": "src\\animation\\yoyo.js",
+          "path": "src/animation/yoyo.js",
           "name": "yoyo.js",
           "size": 655,
           "extension": ".js"
@@ -395,441 +395,441 @@
       "size": 45363
     },
     {
-      "path": "src\\archived",
+      "path": "src/archived",
       "name": "archived",
       "children": [
         {
-          "path": "src\\archived\\000 template.js",
+          "path": "src/archived/000 template.js",
           "name": "000 template.js",
           "size": 413,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\001 texture.js",
+          "path": "src/archived/001 texture.js",
           "name": "001 texture.js",
           "size": 767,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\002 atlas.js",
+          "path": "src/archived/002 atlas.js",
           "name": "002 atlas.js",
           "size": 1112,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\003 trim.js",
+          "path": "src/archived/003 trim.js",
           "name": "003 trim.js",
           "size": 1110,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\004 trim transform.js",
+          "path": "src/archived/004 trim transform.js",
           "name": "004 trim transform.js",
           "size": 1206,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\005 no trim transform.js",
+          "path": "src/archived/005 no trim transform.js",
           "name": "005 no trim transform.js",
           "size": 1216,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\006 crop width.js",
+          "path": "src/archived/006 crop width.js",
           "name": "006 crop width.js",
           "size": 493,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\007 crop x.js",
+          "path": "src/archived/007 crop x.js",
           "name": "007 crop x.js",
           "size": 1226,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\008 crop height.js",
+          "path": "src/archived/008 crop height.js",
           "name": "008 crop height.js",
           "size": 1222,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\009 crop y.js",
+          "path": "src/archived/009 crop y.js",
           "name": "009 crop y.js",
           "size": 1208,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\010 sprite sheet.js",
+          "path": "src/archived/010 sprite sheet.js",
           "name": "010 sprite sheet.js",
           "size": 1130,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\011 multipack atlas.js",
+          "path": "src/archived/011 multipack atlas.js",
           "name": "011 multipack atlas.js",
           "size": 2202,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\012 get frame.js",
+          "path": "src/archived/012 get frame.js",
           "name": "012 get frame.js",
           "size": 2343,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\013 spritesheet from atlas.js",
+          "path": "src/archived/013 spritesheet from atlas.js",
           "name": "013 spritesheet from atlas.js",
           "size": 2531,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\015 webgl renderer 1.js",
+          "path": "src/archived/015 webgl renderer 1.js",
           "name": "015 webgl renderer 1.js",
           "size": 294,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\016 canvas text.js",
+          "path": "src/archived/016 canvas text.js",
           "name": "016 canvas text.js",
           "size": 363,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\017 webgl text.js",
+          "path": "src/archived/017 webgl text.js",
           "name": "017 webgl text.js",
           "size": 419,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\018 tile sprite.js",
+          "path": "src/archived/018 tile sprite.js",
           "name": "018 tile sprite.js",
           "size": 434,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\019 rotation.js",
+          "path": "src/archived/019 rotation.js",
           "name": "019 rotation.js",
           "size": 383,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\020 multiple images.js",
+          "path": "src/archived/020 multiple images.js",
           "name": "020 multiple images.js",
           "size": 751,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\021 images from atlas.js",
+          "path": "src/archived/021 images from atlas.js",
           "name": "021 images from atlas.js",
           "size": 515,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\022 sprite sheet.js",
+          "path": "src/archived/022 sprite sheet.js",
           "name": "022 sprite sheet.js",
           "size": 520,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\025 sprite sheet from atlas.js",
+          "path": "src/archived/025 sprite sheet from atlas.js",
           "name": "025 sprite sheet from atlas.js",
           "size": 1483,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\026 bitmap text.js",
+          "path": "src/archived/026 bitmap text.js",
           "name": "026 bitmap text.js",
           "size": 518,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\030 image test 1.js",
+          "path": "src/archived/030 image test 1.js",
           "name": "030 image test 1.js",
           "size": 655,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\031 stage.js",
+          "path": "src/archived/031 stage.js",
           "name": "031 stage.js",
           "size": 1597,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\032 parent transform.js",
+          "path": "src/archived/032 parent transform.js",
           "name": "032 parent transform.js",
           "size": 900,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\033 stage transform.js",
+          "path": "src/archived/033 stage transform.js",
           "name": "033 stage transform.js",
           "size": 945,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\034 color component.js",
+          "path": "src/archived/034 color component.js",
           "name": "034 color component.js",
           "size": 563,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\035 dirty render.js",
+          "path": "src/archived/035 dirty render.js",
           "name": "035 dirty render.js",
           "size": 930,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\036 fx hook.js",
+          "path": "src/archived/036 fx hook.js",
           "name": "036 fx hook.js",
           "size": 534,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\037 webgl tint.js",
+          "path": "src/archived/037 webgl tint.js",
           "name": "037 webgl tint.js",
           "size": 810,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\038 webgl background color.js",
+          "path": "src/archived/038 webgl background color.js",
           "name": "038 webgl background color.js",
           "size": 536,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\039 webgl image move.js",
+          "path": "src/archived/039 webgl image move.js",
           "name": "039 webgl image move.js",
           "size": 415,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\040 rotated atlas images.js",
+          "path": "src/archived/040 rotated atlas images.js",
           "name": "040 rotated atlas images.js",
           "size": 829,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\041 canvas image mask test.js",
+          "path": "src/archived/041 canvas image mask test.js",
           "name": "041 canvas image mask test.js",
           "size": 493,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\042 webgl fx test 1.js",
+          "path": "src/archived/042 webgl fx test 1.js",
           "name": "042 webgl fx test 1.js",
           "size": 305,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\043 multi textures.js",
+          "path": "src/archived/043 multi textures.js",
           "name": "043 multi textures.js",
           "size": 1418,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\044 blend mode test comparison.js",
+          "path": "src/archived/044 blend mode test comparison.js",
           "name": "044 blend mode test comparison.js",
           "size": 1201,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\044 blend mode test.js",
+          "path": "src/archived/044 blend mode test.js",
           "name": "044 blend mode test.js",
           "size": 1534,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\045 shader swap.js",
+          "path": "src/archived/045 shader swap.js",
           "name": "045 shader swap.js",
           "size": 1488,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\046 shader swap test 2.js",
+          "path": "src/archived/046 shader swap test 2.js",
           "name": "046 shader swap test 2.js",
           "size": 1055,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\050 multi batch test.js",
+          "path": "src/archived/050 multi batch test.js",
           "name": "050 multi batch test.js",
           "size": 2763,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\051 container.js",
+          "path": "src/archived/051 container.js",
           "name": "051 container.js",
           "size": 1698,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\052 container rotation.js",
+          "path": "src/archived/052 container rotation.js",
           "name": "052 container rotation.js",
           "size": 1520,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\053 container position.js",
+          "path": "src/archived/053 container position.js",
           "name": "053 container position.js",
           "size": 2087,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\059 state from extended class.js",
+          "path": "src/archived/059 state from extended class.js",
           "name": "059 state from extended class.js",
           "size": 1106,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\061 multiple states from function.js",
+          "path": "src/archived/061 multiple states from function.js",
           "name": "061 multiple states from function.js",
           "size": 3907,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\062 sine wave crop.js",
+          "path": "src/archived/062 sine wave crop.js",
           "name": "062 sine wave crop.js",
           "size": 1622,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\063 camera.js",
+          "path": "src/archived/063 camera.js",
           "name": "063 camera.js",
           "size": 1305,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\064 mainloop tween.js",
+          "path": "src/archived/064 mainloop tween.js",
           "name": "064 mainloop tween.js",
           "size": 518,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\065 mainloop interpolate.js",
+          "path": "src/archived/065 mainloop interpolate.js",
           "name": "065 mainloop interpolate.js",
           "size": 514,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\066 multiple states demo.js",
+          "path": "src/archived/066 multiple states demo.js",
           "name": "066 multiple states demo.js",
           "size": 12756,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\067 input click.js",
+          "path": "src/archived/067 input click.js",
           "name": "067 input click.js",
           "size": 556,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\068 input image click.js",
+          "path": "src/archived/068 input image click.js",
           "name": "068 input image click.js",
           "size": 1306,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\069 input image drag.js",
+          "path": "src/archived/069 input image drag.js",
           "name": "069 input image drag.js",
           "size": 1346,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\070 arcade physics velocity.js",
+          "path": "src/archived/070 arcade physics velocity.js",
           "name": "070 arcade physics velocity.js",
           "size": 556,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\075 blitter tilemap.js",
+          "path": "src/archived/075 blitter tilemap.js",
           "name": "075 blitter tilemap.js",
           "size": 2145,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\076 config 1.js",
+          "path": "src/archived/076 config 1.js",
           "name": "076 config 1.js",
           "size": 880,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\077 loader single file test.js",
+          "path": "src/archived/077 loader single file test.js",
           "name": "077 loader single file test.js",
           "size": 628,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\087 load complete event.js",
+          "path": "src/archived/087 load complete event.js",
           "name": "087 load complete event.js",
           "size": 436,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\088 load json.js",
+          "path": "src/archived/088 load json.js",
           "name": "088 load json.js",
           "size": 344,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\089 math.js",
+          "path": "src/archived/089 math.js",
           "name": "089 math.js",
           "size": 298,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\090 images alpha.js",
+          "path": "src/archived/090 images alpha.js",
           "name": "090 images alpha.js",
           "size": 416,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\091 image parent alpha.js",
+          "path": "src/archived/091 image parent alpha.js",
           "name": "091 image parent alpha.js",
           "size": 437,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\095 rectangle 1.js",
+          "path": "src/archived/095 rectangle 1.js",
           "name": "095 rectangle 1.js",
           "size": 547,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\canvas renderer",
+          "path": "src/archived/canvas renderer",
           "name": "canvas renderer",
           "children": [
             {
-              "path": "src\\archived\\canvas renderer\\background color.js",
+              "path": "src/archived/canvas renderer/background color.js",
               "name": "background color.js",
               "size": 585,
               "extension": ".js"
             },
             {
-              "path": "src\\archived\\canvas renderer\\multiple images.js",
+              "path": "src/archived/canvas renderer/multiple images.js",
               "name": "multiple images.js",
               "size": 491,
               "extension": ".js"
             },
             {
-              "path": "src\\archived\\canvas renderer\\nemesis.js",
+              "path": "src/archived/canvas renderer/nemesis.js",
               "name": "nemesis.js",
               "size": 3166,
               "extension": ".js"
             },
             {
-              "path": "src\\archived\\canvas renderer\\single image.js",
+              "path": "src/archived/canvas renderer/single image.js",
               "name": "single image.js",
               "size": 365,
               "extension": ".js"
             },
             {
-              "path": "src\\archived\\canvas renderer\\test 2.js",
+              "path": "src/archived/canvas renderer/test 2.js",
               "name": "test 2.js",
               "size": 518,
               "extension": ".js"
             },
             {
-              "path": "src\\archived\\canvas renderer\\zoom x2.js",
+              "path": "src/archived/canvas renderer/zoom x2.js",
               "name": "zoom x2.js",
               "size": 856,
               "extension": ".js"
@@ -838,11 +838,11 @@
           "size": 5981
         },
         {
-          "path": "src\\archived\\container",
+          "path": "src/archived/container",
           "name": "container",
           "children": [
             {
-              "path": "src\\archived\\container\\basic container.js",
+              "path": "src/archived/container/basic container.js",
               "name": "basic container.js",
               "size": 922,
               "extension": ".js"
@@ -851,35 +851,35 @@
           "size": 922
         },
         {
-          "path": "src\\archived\\game resize stretch image.js",
+          "path": "src/archived/game resize stretch image.js",
           "name": "game resize stretch image.js",
           "size": 1182,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\game resize.js",
+          "path": "src/archived/game resize.js",
           "name": "game resize.js",
           "size": 1169,
           "extension": ".js"
         },
         {
-          "path": "src\\archived\\pixel field",
+          "path": "src/archived/pixel field",
           "name": "pixel field",
           "children": [
             {
-              "path": "src\\archived\\pixel field\\047 pixelfield.js",
+              "path": "src/archived/pixel field/047 pixelfield.js",
               "name": "047 pixelfield.js",
               "size": 563,
               "extension": ".js"
             },
             {
-              "path": "src\\archived\\pixel field\\048 pixelfield stars.js",
+              "path": "src/archived/pixel field/048 pixelfield stars.js",
               "name": "048 pixelfield stars.js",
               "size": 1080,
               "extension": ".js"
             },
             {
-              "path": "src\\archived\\pixel field\\049 pixelfield plot.js",
+              "path": "src/archived/pixel field/049 pixelfield plot.js",
               "name": "049 pixelfield plot.js",
               "size": 1585,
               "extension": ".js"
@@ -888,29 +888,29 @@
           "size": 3228
         },
         {
-          "path": "src\\archived\\scale",
+          "path": "src/archived/scale",
           "name": "scale",
           "children": [
             {
-              "path": "src\\archived\\scale\\resolution.js",
+              "path": "src/archived/scale/resolution.js",
               "name": "resolution.js",
               "size": 1566,
               "extension": ".js"
             },
             {
-              "path": "src\\archived\\scale\\scaled canvas.js",
+              "path": "src/archived/scale/scaled canvas.js",
               "name": "scaled canvas.js",
               "size": 469,
               "extension": ".js"
             },
             {
-              "path": "src\\archived\\scale\\sprite ondown.js",
+              "path": "src/archived/scale/sprite ondown.js",
               "name": "sprite ondown.js",
               "size": 1325,
               "extension": ".js"
             },
             {
-              "path": "src\\archived\\scale\\text resolution.js",
+              "path": "src/archived/scale/text resolution.js",
               "name": "text resolution.js",
               "size": 1587,
               "extension": ".js"
@@ -919,23 +919,23 @@
           "size": 4947
         },
         {
-          "path": "src\\archived\\sprite renderer",
+          "path": "src/archived/sprite renderer",
           "name": "sprite renderer",
           "children": [
             {
-              "path": "src\\archived\\sprite renderer\\benchmark 1.js",
+              "path": "src/archived/sprite renderer/benchmark 1.js",
               "name": "benchmark 1.js",
               "size": 830,
               "extension": ".js"
             },
             {
-              "path": "src\\archived\\sprite renderer\\benchmark 2.js",
+              "path": "src/archived/sprite renderer/benchmark 2.js",
               "name": "benchmark 2.js",
               "size": 1157,
               "extension": ".js"
             },
             {
-              "path": "src\\archived\\sprite renderer\\bunny test 1.js",
+              "path": "src/archived/sprite renderer/bunny test 1.js",
               "name": "bunny test 1.js",
               "size": 581,
               "extension": ".js"
@@ -944,7 +944,7 @@
           "size": 2568
         },
         {
-          "path": "src\\archived\\trail test.js",
+          "path": "src/archived/trail test.js",
           "name": "trail test.js",
           "size": 10328,
           "extension": ".js"
@@ -953,63 +953,63 @@
       "size": 110083
     },
     {
-      "path": "src\\audio",
+      "path": "src/audio",
       "name": "audio",
       "children": [
         {
-          "path": "src\\audio\\HTML5 Audio",
+          "path": "src/audio/HTML5 Audio",
           "name": "HTML5 Audio",
           "children": [
             {
-              "path": "src\\audio\\HTML5 Audio\\AudioSprite.js",
+              "path": "src/audio/HTML5 Audio/AudioSprite.js",
               "name": "AudioSprite.js",
               "size": 2215,
               "extension": ".js"
             },
             {
-              "path": "src\\audio\\HTML5 Audio\\Basic Playback and Events.js",
+              "path": "src/audio/HTML5 Audio/Basic Playback and Events.js",
               "name": "Basic Playback and Events.js",
               "size": 13787,
               "extension": ".js"
             },
             {
-              "path": "src\\audio\\HTML5 Audio\\Loop Delay.js",
+              "path": "src/audio/HTML5 Audio/Loop Delay.js",
               "name": "Loop Delay.js",
               "size": 6322,
               "extension": ".js"
             },
             {
-              "path": "src\\audio\\HTML5 Audio\\Markers - Pause, Resume.js",
+              "path": "src/audio/HTML5 Audio/Markers - Pause, Resume.js",
               "name": "Markers - Pause, Resume.js",
               "size": 3740,
               "extension": ".js"
             },
             {
-              "path": "src\\audio\\HTML5 Audio\\Markers - Play.js",
+              "path": "src/audio/HTML5 Audio/Markers - Play.js",
               "name": "Markers - Play.js",
               "size": 2665,
               "extension": ".js"
             },
             {
-              "path": "src\\audio\\HTML5 Audio\\play audio file.js",
+              "path": "src/audio/HTML5 Audio/play audio file.js",
               "name": "play audio file.js",
               "size": 686,
               "extension": ".js"
             },
             {
-              "path": "src\\audio\\HTML5 Audio\\play audio from child scene.js",
+              "path": "src/audio/HTML5 Audio/play audio from child scene.js",
               "name": "play audio from child scene.js",
               "size": 3188,
               "extension": ".js"
             },
             {
-              "path": "src\\audio\\HTML5 Audio\\Seek.js",
+              "path": "src/audio/HTML5 Audio/Seek.js",
               "name": "Seek.js",
               "size": 3625,
               "extension": ".js"
             },
             {
-              "path": "src\\audio\\HTML5 Audio\\Volume Mute Rate Detune.js",
+              "path": "src/audio/HTML5 Audio/Volume Mute Rate Detune.js",
               "name": "Volume Mute Rate Detune.js",
               "size": 3912,
               "extension": ".js"
@@ -1018,47 +1018,47 @@
           "size": 40140
         },
         {
-          "path": "src\\audio\\No Audio",
+          "path": "src/audio/No Audio",
           "name": "No Audio",
           "children": [
             {
-              "path": "src\\audio\\No Audio\\AudioSprite.js",
+              "path": "src/audio/No Audio/AudioSprite.js",
               "name": "AudioSprite.js",
               "size": 2231,
               "extension": ".js"
             },
             {
-              "path": "src\\audio\\No Audio\\Basic Playback and Events.js",
+              "path": "src/audio/No Audio/Basic Playback and Events.js",
               "name": "Basic Playback and Events.js",
               "size": 13748,
               "extension": ".js"
             },
             {
-              "path": "src\\audio\\No Audio\\Loop Delay.js",
+              "path": "src/audio/No Audio/Loop Delay.js",
               "name": "Loop Delay.js",
               "size": 5772,
               "extension": ".js"
             },
             {
-              "path": "src\\audio\\No Audio\\Markers - Pause, Resume.js",
+              "path": "src/audio/No Audio/Markers - Pause, Resume.js",
               "name": "Markers - Pause, Resume.js",
               "size": 3732,
               "extension": ".js"
             },
             {
-              "path": "src\\audio\\No Audio\\Markers - Play.js",
+              "path": "src/audio/No Audio/Markers - Play.js",
               "name": "Markers - Play.js",
               "size": 2625,
               "extension": ".js"
             },
             {
-              "path": "src\\audio\\No Audio\\Seek.js",
+              "path": "src/audio/No Audio/Seek.js",
               "name": "Seek.js",
               "size": 3614,
               "extension": ".js"
             },
             {
-              "path": "src\\audio\\No Audio\\Volume Mute Rate Detune.js",
+              "path": "src/audio/No Audio/Volume Mute Rate Detune.js",
               "name": "Volume Mute Rate Detune.js",
               "size": 3896,
               "extension": ".js"
@@ -1067,11 +1067,11 @@
           "size": 35618
         },
         {
-          "path": "src\\audio\\SID",
+          "path": "src/audio/SID",
           "name": "SID",
           "children": [
             {
-              "path": "src\\audio\\SID\\test.js",
+              "path": "src/audio/SID/test.js",
               "name": "test.js",
               "size": 2429,
               "extension": ".js"
@@ -1080,71 +1080,71 @@
           "size": 2429
         },
         {
-          "path": "src\\audio\\Web Audio",
+          "path": "src/audio/Web Audio",
           "name": "Web Audio",
           "children": [
             {
-              "path": "src\\audio\\Web Audio\\AudioSprite.js",
+              "path": "src/audio/Web Audio/AudioSprite.js",
               "name": "AudioSprite.js",
               "size": 2139,
               "extension": ".js"
             },
             {
-              "path": "src\\audio\\Web Audio\\Basic Playback and Events.js",
+              "path": "src/audio/Web Audio/Basic Playback and Events.js",
               "name": "Basic Playback and Events.js",
               "size": 13703,
               "extension": ".js"
             },
             {
-              "path": "src\\audio\\Web Audio\\Loop Delay.js",
+              "path": "src/audio/Web Audio/Loop Delay.js",
               "name": "Loop Delay.js",
               "size": 5727,
               "extension": ".js"
             },
             {
-              "path": "src\\audio\\Web Audio\\Markers - Pause, Resume.js",
+              "path": "src/audio/Web Audio/Markers - Pause, Resume.js",
               "name": "Markers - Pause, Resume.js",
               "size": 3687,
               "extension": ".js"
             },
             {
-              "path": "src\\audio\\Web Audio\\Markers - Play.js",
+              "path": "src/audio/Web Audio/Markers - Play.js",
               "name": "Markers - Play.js",
               "size": 2580,
               "extension": ".js"
             },
             {
-              "path": "src\\audio\\Web Audio\\play audio file.js",
+              "path": "src/audio/Web Audio/play audio file.js",
               "name": "play audio file.js",
               "size": 633,
               "extension": ".js"
             },
             {
-              "path": "src\\audio\\Web Audio\\play audio from child scene.js",
+              "path": "src/audio/Web Audio/play audio from child scene.js",
               "name": "play audio from child scene.js",
               "size": 3135,
               "extension": ".js"
             },
             {
-              "path": "src\\audio\\Web Audio\\play sound on keypress.js",
+              "path": "src/audio/Web Audio/play sound on keypress.js",
               "name": "play sound on keypress.js",
               "size": 2524,
               "extension": ".js"
             },
             {
-              "path": "src\\audio\\Web Audio\\Reuse AudioContext.js",
+              "path": "src/audio/Web Audio/Reuse AudioContext.js",
               "name": "Reuse AudioContext.js",
               "size": 2064,
               "extension": ".js"
             },
             {
-              "path": "src\\audio\\Web Audio\\Seek.js",
+              "path": "src/audio/Web Audio/Seek.js",
               "name": "Seek.js",
               "size": 3572,
               "extension": ".js"
             },
             {
-              "path": "src\\audio\\Web Audio\\Volume Mute Rate Detune.js",
+              "path": "src/audio/Web Audio/Volume Mute Rate Detune.js",
               "name": "Volume Mute Rate Detune.js",
               "size": 3857,
               "extension": ".js"
@@ -1156,275 +1156,275 @@
       "size": 121808
     },
     {
-      "path": "src\\bugs",
+      "path": "src/bugs",
       "name": "bugs",
       "children": [
         {
-          "path": "src\\bugs\\anim remove.js",
+          "path": "src/bugs/anim remove.js",
           "name": "anim remove.js",
           "size": 917,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\ap origin.js",
+          "path": "src/bugs/ap origin.js",
           "name": "ap origin.js",
           "size": 658,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\ap postupdate.js",
+          "path": "src/bugs/ap postupdate.js",
           "name": "ap postupdate.js",
           "size": 537,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\ap tilemap.js",
+          "path": "src/bugs/ap tilemap.js",
           "name": "ap tilemap.js",
           "size": 4530,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\cam zoom.js",
+          "path": "src/bugs/cam zoom.js",
           "name": "cam zoom.js",
           "size": 481,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\circ.js",
+          "path": "src/bugs/circ.js",
           "name": "circ.js",
           "size": 803,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\click scenes.js",
+          "path": "src/bugs/click scenes.js",
           "name": "click scenes.js",
           "size": 2092,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\container drag.js",
+          "path": "src/bugs/container drag.js",
           "name": "container drag.js",
           "size": 891,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\container over.js",
+          "path": "src/bugs/container over.js",
           "name": "container over.js",
           "size": 961,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\container tilesprite.js",
+          "path": "src/bugs/container tilesprite.js",
           "name": "container tilesprite.js",
           "size": 2088,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\destroy.js",
+          "path": "src/bugs/destroy.js",
           "name": "destroy.js",
           "size": 1254,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\dom resize.js",
+          "path": "src/bugs/dom resize.js",
           "name": "dom resize.js",
           "size": 675,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\extern.js",
+          "path": "src/bugs/extern.js",
           "name": "extern.js",
           "size": 1676,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\extern2.js",
+          "path": "src/bugs/extern2.js",
           "name": "extern2.js",
           "size": 4579,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\input res.js",
+          "path": "src/bugs/input res.js",
           "name": "input res.js",
           "size": 2586,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\interactive destroy.js",
+          "path": "src/bugs/interactive destroy.js",
           "name": "interactive destroy.js",
           "size": 1998,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\ios.js",
+          "path": "src/bugs/ios.js",
           "name": "ios.js",
           "size": 2714,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\light 2.js",
+          "path": "src/bugs/light 2.js",
           "name": "light 2.js",
           "size": 1664,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\light.js",
+          "path": "src/bugs/light.js",
           "name": "light.js",
           "size": 1208,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\map zoom canvas.js",
+          "path": "src/bugs/map zoom canvas.js",
           "name": "map zoom canvas.js",
           "size": 1990,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\multi pan.js",
+          "path": "src/bugs/multi pan.js",
           "name": "multi pan.js",
           "size": 2737,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\order.js",
+          "path": "src/bugs/order.js",
           "name": "order.js",
           "size": 1309,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\pivot.js",
+          "path": "src/bugs/pivot.js",
           "name": "pivot.js",
           "size": 3116,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\pixi text.js",
+          "path": "src/bugs/pixi text.js",
           "name": "pixi text.js",
           "size": 2175,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\poly.js",
+          "path": "src/bugs/poly.js",
           "name": "poly.js",
           "size": 4289,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\rad test.js",
+          "path": "src/bugs/rad test.js",
           "name": "rad test.js",
           "size": 3234,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\rect scale.js",
+          "path": "src/bugs/rect scale.js",
           "name": "rect scale.js",
           "size": 1359,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\reverse anim.js",
+          "path": "src/bugs/reverse anim.js",
           "name": "reverse anim.js",
           "size": 2865,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\rot.js",
+          "path": "src/bugs/rot.js",
           "name": "rot.js",
           "size": 2513,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\rounded texture.js",
+          "path": "src/bugs/rounded texture.js",
           "name": "rounded texture.js",
           "size": 487,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\rt camera crop.js",
+          "path": "src/bugs/rt camera crop.js",
           "name": "rt camera crop.js",
           "size": 1694,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\rt camera scroll.js",
+          "path": "src/bugs/rt camera scroll.js",
           "name": "rt camera scroll.js",
           "size": 1592,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\rt crop.js",
+          "path": "src/bugs/rt crop.js",
           "name": "rt crop.js",
           "size": 1437,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\rt destroy.js",
+          "path": "src/bugs/rt destroy.js",
           "name": "rt destroy.js",
           "size": 1372,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\rt fill.js",
+          "path": "src/bugs/rt fill.js",
           "name": "rt fill.js",
           "size": 608,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\scene keys.js",
+          "path": "src/bugs/scene keys.js",
           "name": "scene keys.js",
           "size": 1725,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\shader to rt frame.js",
+          "path": "src/bugs/shader to rt frame.js",
           "name": "shader to rt frame.js",
           "size": 1375,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\shader to rt.js",
+          "path": "src/bugs/shader to rt.js",
           "name": "shader to rt.js",
           "size": 1097,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\skip tile.js",
+          "path": "src/bugs/skip tile.js",
           "name": "skip tile.js",
           "size": 2168,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\stroke.js",
+          "path": "src/bugs/stroke.js",
           "name": "stroke.js",
           "size": 1365,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\text.js",
+          "path": "src/bugs/text.js",
           "name": "text.js",
           "size": 650,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\tilemap resize.js",
+          "path": "src/bugs/tilemap resize.js",
           "name": "tilemap resize.js",
           "size": 3891,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\tint.js",
+          "path": "src/bugs/tint.js",
           "name": "tint.js",
           "size": 2378,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\ts 2.js",
+          "path": "src/bugs/ts 2.js",
           "name": "ts 2.js",
           "size": 953,
           "extension": ".js"
         },
         {
-          "path": "src\\bugs\\y2k.js",
+          "path": "src/bugs/y2k.js",
           "name": "y2k.js",
           "size": 1473,
           "extension": ".js"
@@ -1433,23 +1433,23 @@
       "size": 82164
     },
     {
-      "path": "src\\cache",
+      "path": "src/cache",
       "name": "cache",
       "children": [
         {
-          "path": "src\\cache\\json file.js",
+          "path": "src/cache/json file.js",
           "name": "json file.js",
           "size": 363,
           "extension": ".js"
         },
         {
-          "path": "src\\cache\\text file.js",
+          "path": "src/cache/text file.js",
           "name": "text file.js",
           "size": 356,
           "extension": ".js"
         },
         {
-          "path": "src\\cache\\xml file.js",
+          "path": "src/cache/xml file.js",
           "name": "xml file.js",
           "size": 551,
           "extension": ".js"
@@ -1458,129 +1458,129 @@
       "size": 1270
     },
     {
-      "path": "src\\camera",
+      "path": "src/camera",
       "name": "camera",
       "children": [
         {
-          "path": "src\\camera\\16 camera shader test.js",
+          "path": "src/camera/16 camera shader test.js",
           "name": "16 camera shader test.js",
           "size": 4156,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\16 camera test.js",
+          "path": "src/camera/16 camera test.js",
           "name": "16 camera test.js",
           "size": 884,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\32 camera test.js",
+          "path": "src/camera/32 camera test.js",
           "name": "32 camera test.js",
           "size": 883,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\3D camera",
+          "path": "src/camera/3D camera",
           "name": "3D camera",
           "children": [
             {
-              "path": "src\\camera\\3D camera\\blend cube.js",
+              "path": "src/camera/3D camera/blend cube.js",
               "name": "blend cube.js",
               "size": 3136,
               "extension": ".js"
             },
             {
-              "path": "src\\camera\\3D camera\\distance alpha.js",
+              "path": "src/camera/3D camera/distance alpha.js",
               "name": "distance alpha.js",
               "size": 1607,
               "extension": ".js"
             },
             {
-              "path": "src\\camera\\3D camera\\dot sphere.js",
+              "path": "src/camera/3D camera/dot sphere.js",
               "name": "dot sphere.js",
               "size": 3054,
               "extension": ".js"
             },
             {
-              "path": "src\\camera\\3D camera\\fixed scale.js",
+              "path": "src/camera/3D camera/fixed scale.js",
               "name": "fixed scale.js",
               "size": 2213,
               "extension": ".js"
             },
             {
-              "path": "src\\camera\\3D camera\\floor.js",
+              "path": "src/camera/3D camera/floor.js",
               "name": "floor.js",
               "size": 1507,
               "extension": ".js"
             },
             {
-              "path": "src\\camera\\3D camera\\forest.js",
+              "path": "src/camera/3D camera/forest.js",
               "name": "forest.js",
               "size": 2180,
               "extension": ".js"
             },
             {
-              "path": "src\\camera\\3D camera\\meadow.js",
+              "path": "src/camera/3D camera/meadow.js",
               "name": "meadow.js",
               "size": 3909,
               "extension": ".js"
             },
             {
-              "path": "src\\camera\\3D camera\\orthographic camera.js",
+              "path": "src/camera/3D camera/orthographic camera.js",
               "name": "orthographic camera.js",
               "size": 1780,
               "extension": ".js"
             },
             {
-              "path": "src\\camera\\3D camera\\perspective camera.js",
+              "path": "src/camera/3D camera/perspective camera.js",
               "name": "perspective camera.js",
               "size": 1860,
               "extension": ".js"
             },
             {
-              "path": "src\\camera\\3D camera\\rectangle scaled.js",
+              "path": "src/camera/3D camera/rectangle scaled.js",
               "name": "rectangle scaled.js",
               "size": 2891,
               "extension": ".js"
             },
             {
-              "path": "src\\camera\\3D camera\\rectangle.js",
+              "path": "src/camera/3D camera/rectangle.js",
               "name": "rectangle.js",
               "size": 2886,
               "extension": ".js"
             },
             {
-              "path": "src\\camera\\3D camera\\road 1.js",
+              "path": "src/camera/3D camera/road 1.js",
               "name": "road 1.js",
               "size": 2213,
               "extension": ".js"
             },
             {
-              "path": "src\\camera\\3D camera\\road 2.js",
+              "path": "src/camera/3D camera/road 2.js",
               "name": "road 2.js",
               "size": 3512,
               "extension": ".js"
             },
             {
-              "path": "src\\camera\\3D camera\\rotate around.js",
+              "path": "src/camera/3D camera/rotate around.js",
               "name": "rotate around.js",
               "size": 2061,
               "extension": ".js"
             },
             {
-              "path": "src\\camera\\3D camera\\rotate camera around cube.js",
+              "path": "src/camera/3D camera/rotate camera around cube.js",
               "name": "rotate camera around cube.js",
               "size": 4137,
               "extension": ".js"
             },
             {
-              "path": "src\\camera\\3D camera\\rotate camera.js",
+              "path": "src/camera/3D camera/rotate camera.js",
               "name": "rotate camera.js",
               "size": 1873,
               "extension": ".js"
             },
             {
-              "path": "src\\camera\\3D camera\\rotate image to camera.js",
+              "path": "src/camera/3D camera/rotate image to camera.js",
               "name": "rotate image to camera.js",
               "size": 3921,
               "extension": ".js"
@@ -1589,281 +1589,281 @@
           "size": 44740
         },
         {
-          "path": "src\\camera\\add and remove test.js",
+          "path": "src/camera/add and remove test.js",
           "name": "add and remove test.js",
           "size": 1791,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\add camera on click.js",
+          "path": "src/camera/add camera on click.js",
           "name": "add camera on click.js",
           "size": 991,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\background color interpolate.js",
+          "path": "src/camera/background color interpolate.js",
           "name": "background color interpolate.js",
           "size": 1196,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\background color.js",
+          "path": "src/camera/background color.js",
           "name": "background color.js",
           "size": 1325,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\basics.js",
+          "path": "src/camera/basics.js",
           "name": "basics.js",
           "size": 1146,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\bounds at zero.js",
+          "path": "src/camera/bounds at zero.js",
           "name": "bounds at zero.js",
           "size": 2711,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\camera alpha.js",
+          "path": "src/camera/camera alpha.js",
           "name": "camera alpha.js",
           "size": 2321,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\camera blur shader.js",
+          "path": "src/camera/camera blur shader.js",
           "name": "camera blur shader.js",
           "size": 4124,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\camera effect callbacks.js",
+          "path": "src/camera/camera effect callbacks.js",
           "name": "camera effect callbacks.js",
           "size": 978,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\camera fade in and out.js",
+          "path": "src/camera/camera fade in and out.js",
           "name": "camera fade in and out.js",
           "size": 741,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\camera fade out and in.js",
+          "path": "src/camera/camera fade out and in.js",
           "name": "camera fade out and in.js",
           "size": 691,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\camera filter.js",
+          "path": "src/camera/camera filter.js",
           "name": "camera filter.js",
           "size": 1572,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\camera-effects.js",
+          "path": "src/camera/camera-effects.js",
           "name": "camera-effects.js",
           "size": 956,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\cameras from state config.js",
+          "path": "src/camera/cameras from state config.js",
           "name": "cameras from state config.js",
           "size": 1101,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\center on.js",
+          "path": "src/camera/center on.js",
           "name": "center on.js",
           "size": 1815,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\change camera shader.js",
+          "path": "src/camera/change camera shader.js",
           "name": "change camera shader.js",
           "size": 3719,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\cross scene object placement.js",
+          "path": "src/camera/cross scene object placement.js",
           "name": "cross scene object placement.js",
           "size": 4147,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\fade.js",
+          "path": "src/camera/fade.js",
           "name": "fade.js",
           "size": 1197,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\fixed to camera.js",
+          "path": "src/camera/fixed to camera.js",
           "name": "fixed to camera.js",
           "size": 1664,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\flash.js",
+          "path": "src/camera/flash.js",
           "name": "flash.js",
           "size": 1007,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\follow offset.js",
+          "path": "src/camera/follow offset.js",
           "name": "follow offset.js",
           "size": 1797,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\follow sprite small bounds.js",
+          "path": "src/camera/follow sprite small bounds.js",
           "name": "follow sprite small bounds.js",
           "size": 3224,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\follow sprite with deadzone.js",
+          "path": "src/camera/follow sprite with deadzone.js",
           "name": "follow sprite with deadzone.js",
           "size": 4389,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\follow sprite.js",
+          "path": "src/camera/follow sprite.js",
           "name": "follow sprite.js",
           "size": 1151,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\follow user controlled sprite.js",
+          "path": "src/camera/follow user controlled sprite.js",
           "name": "follow user controlled sprite.js",
           "size": 1599,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\follow zoom tilemap.js",
+          "path": "src/camera/follow zoom tilemap.js",
           "name": "follow zoom tilemap.js",
           "size": 2061,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\follow zoom.js",
+          "path": "src/camera/follow zoom.js",
           "name": "follow zoom.js",
           "size": 1821,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\game shader test 1.js",
+          "path": "src/camera/game shader test 1.js",
           "name": "game shader test 1.js",
           "size": 5420,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\game shader test 2.js",
+          "path": "src/camera/game shader test 2.js",
           "name": "game shader test 2.js",
           "size": 5239,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\game shader test 3.js",
+          "path": "src/camera/game shader test 3.js",
           "name": "game shader test 3.js",
           "size": 5457,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\graphics landscape.js",
+          "path": "src/camera/graphics landscape.js",
           "name": "graphics landscape.js",
           "size": 2995,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\ignore container.js",
+          "path": "src/camera/ignore container.js",
           "name": "ignore container.js",
           "size": 1335,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\ignore gameobjects in containers.js",
+          "path": "src/camera/ignore gameobjects in containers.js",
           "name": "ignore gameobjects in containers.js",
           "size": 1852,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\ignore gameobjects.js",
+          "path": "src/camera/ignore gameobjects.js",
           "name": "ignore gameobjects.js",
           "size": 1617,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\ignore group children.js",
+          "path": "src/camera/ignore group children.js",
           "name": "ignore group children.js",
           "size": 1631,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\ignore.js",
+          "path": "src/camera/ignore.js",
           "name": "ignore.js",
           "size": 1199,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\minimap camera.js",
+          "path": "src/camera/minimap camera.js",
           "name": "minimap camera.js",
           "size": 5378,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\move camera with keys.js",
+          "path": "src/camera/move camera with keys.js",
           "name": "move camera with keys.js",
           "size": 1824,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\multi camera",
+          "path": "src/camera/multi camera",
           "name": "multi camera",
           "children": [
             {
-              "path": "src\\camera\\multi camera\\boot.json",
+              "path": "src/camera/multi camera/boot.json",
               "name": "boot.json",
               "size": 177,
               "extension": ".json"
             },
             {
-              "path": "src\\camera\\multi camera\\Controller.js",
+              "path": "src/camera/multi camera/Controller.js",
               "name": "Controller.js",
               "size": 7912,
               "extension": ".js"
             },
             {
-              "path": "src\\camera\\multi camera\\DemoA.js",
+              "path": "src/camera/multi camera/DemoA.js",
               "name": "DemoA.js",
               "size": 1619,
               "extension": ".js"
             },
             {
-              "path": "src\\camera\\multi camera\\DemoB.js",
+              "path": "src/camera/multi camera/DemoB.js",
               "name": "DemoB.js",
               "size": 2072,
               "extension": ".js"
             },
             {
-              "path": "src\\camera\\multi camera\\DemoC.js",
+              "path": "src/camera/multi camera/DemoC.js",
               "name": "DemoC.js",
               "size": 1150,
               "extension": ".js"
             },
             {
-              "path": "src\\camera\\multi camera\\DemoD.js",
+              "path": "src/camera/multi camera/DemoD.js",
               "name": "DemoD.js",
               "size": 4681,
               "extension": ".js"
             },
             {
-              "path": "src\\camera\\multi camera\\game.js",
+              "path": "src/camera/multi camera/game.js",
               "name": "game.js",
               "size": 238,
               "extension": ".js"
             },
             {
-              "path": "src\\camera\\multi camera\\Obj3D.js",
+              "path": "src/camera/multi camera/Obj3D.js",
               "name": "Obj3D.js",
               "size": 2992,
               "extension": ".js"
@@ -1872,175 +1872,175 @@
           "size": 20841
         },
         {
-          "path": "src\\camera\\multiple-cameras.js",
+          "path": "src/camera/multiple-cameras.js",
           "name": "multiple-cameras.js",
           "size": 676,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\origin.js",
+          "path": "src/camera/origin.js",
           "name": "origin.js",
           "size": 1137,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\overlap.js",
+          "path": "src/camera/overlap.js",
           "name": "overlap.js",
           "size": 860,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\pan to.js",
+          "path": "src/camera/pan to.js",
           "name": "pan to.js",
           "size": 2005,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\remove camera on click.js",
+          "path": "src/camera/remove camera on click.js",
           "name": "remove camera on click.js",
           "size": 1570,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\render to texture canvas.js",
+          "path": "src/camera/render to texture canvas.js",
           "name": "render to texture canvas.js",
           "size": 1213,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\render to texture shader 2.js",
+          "path": "src/camera/render to texture shader 2.js",
           "name": "render to texture shader 2.js",
           "size": 3220,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\render to texture shader 3.js",
+          "path": "src/camera/render to texture shader 3.js",
           "name": "render to texture shader 3.js",
           "size": 2355,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\render to texture shader 4.js",
+          "path": "src/camera/render to texture shader 4.js",
           "name": "render to texture shader 4.js",
           "size": 3084,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\render to texture shader 5.js",
+          "path": "src/camera/render to texture shader 5.js",
           "name": "render to texture shader 5.js",
           "size": 3518,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\render to texture shader 6.js",
+          "path": "src/camera/render to texture shader 6.js",
           "name": "render to texture shader 6.js",
           "size": 2500,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\render to texture shader.js",
+          "path": "src/camera/render to texture shader.js",
           "name": "render to texture shader.js",
           "size": 2556,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\render to texture.js",
+          "path": "src/camera/render to texture.js",
           "name": "render to texture.js",
           "size": 2693,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\rotate camera.js",
+          "path": "src/camera/rotate camera.js",
           "name": "rotate camera.js",
           "size": 1813,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\round pixels.js",
+          "path": "src/camera/round pixels.js",
           "name": "round pixels.js",
           "size": 505,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\scroll view.js",
+          "path": "src/camera/scroll view.js",
           "name": "scroll view.js",
           "size": 1580,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\select shader test.js",
+          "path": "src/camera/select shader test.js",
           "name": "select shader test.js",
           "size": 2669,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\set bounds.js",
+          "path": "src/camera/set bounds.js",
           "name": "set bounds.js",
           "size": 1066,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\set scroll factor.js",
+          "path": "src/camera/set scroll factor.js",
           "name": "set scroll factor.js",
           "size": 1911,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\set small bounds.js",
+          "path": "src/camera/set small bounds.js",
           "name": "set small bounds.js",
           "size": 1125,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\set viewport.js",
+          "path": "src/camera/set viewport.js",
           "name": "set viewport.js",
           "size": 623,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\shader multi cam test.js",
+          "path": "src/camera/shader multi cam test.js",
           "name": "shader multi cam test.js",
           "size": 2316,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\shake.js",
+          "path": "src/camera/shake.js",
           "name": "shake.js",
           "size": 992,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\single small camera.js",
+          "path": "src/camera/single small camera.js",
           "name": "single small camera.js",
           "size": 2105,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\tile map with camera shake.js",
+          "path": "src/camera/tile map with camera shake.js",
           "name": "tile map with camera shake.js",
           "size": 1347,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\world camera.js",
+          "path": "src/camera/world camera.js",
           "name": "world camera.js",
           "size": 5377,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\world coordinate from another scene.js",
+          "path": "src/camera/world coordinate from another scene.js",
           "name": "world coordinate from another scene.js",
           "size": 3161,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\world view.js",
+          "path": "src/camera/world view.js",
           "name": "world view.js",
           "size": 1625,
           "extension": ".js"
         },
         {
-          "path": "src\\camera\\zoom to.js",
+          "path": "src/camera/zoom to.js",
           "name": "zoom to.js",
           "size": 2113,
           "extension": ".js"
@@ -2049,51 +2049,51 @@
       "size": 214401
     },
     {
-      "path": "src\\components",
+      "path": "src/components",
       "name": "components",
       "children": [
         {
-          "path": "src\\components\\data",
+          "path": "src/components/data",
           "name": "data",
           "children": [
             {
-              "path": "src\\components\\data\\change data event.js",
+              "path": "src/components/data/change data event.js",
               "name": "change data event.js",
               "size": 1825,
               "extension": ".js"
             },
             {
-              "path": "src\\components\\data\\data values.js",
+              "path": "src/components/data/data values.js",
               "name": "data values.js",
               "size": 1358,
               "extension": ".js"
             },
             {
-              "path": "src\\components\\data\\get and set data values.js",
+              "path": "src/components/data/get and set data values.js",
               "name": "get and set data values.js",
               "size": 923,
               "extension": ".js"
             },
             {
-              "path": "src\\components\\data\\query data.js",
+              "path": "src/components/data/query data.js",
               "name": "query data.js",
               "size": 830,
               "extension": ".js"
             },
             {
-              "path": "src\\components\\data\\set data event.js",
+              "path": "src/components/data/set data event.js",
               "name": "set data event.js",
               "size": 2127,
               "extension": ".js"
             },
             {
-              "path": "src\\components\\data\\set multiple values.js",
+              "path": "src/components/data/set multiple values.js",
               "name": "set multiple values.js",
               "size": 1272,
               "extension": ".js"
             },
             {
-              "path": "src\\components\\data\\store scene data.js",
+              "path": "src/components/data/store scene data.js",
               "name": "store scene data.js",
               "size": 648,
               "extension": ".js"
@@ -2105,35 +2105,35 @@
       "size": 8983
     },
     {
-      "path": "src\\demoscene",
+      "path": "src/demoscene",
       "name": "demoscene",
       "children": [
         {
-          "path": "src\\demoscene\\birdy nam nam.js",
+          "path": "src/demoscene/birdy nam nam.js",
           "name": "birdy nam nam.js",
           "size": 3608,
           "extension": ".js"
         },
         {
-          "path": "src\\demoscene\\chunky raster bars.js",
+          "path": "src/demoscene/chunky raster bars.js",
           "name": "chunky raster bars.js",
           "size": 1029,
           "extension": ".js"
         },
         {
-          "path": "src\\demoscene\\raster carpet.js",
+          "path": "src/demoscene/raster carpet.js",
           "name": "raster carpet.js",
           "size": 1340,
           "extension": ".js"
         },
         {
-          "path": "src\\demoscene\\raster wave.js",
+          "path": "src/demoscene/raster wave.js",
           "name": "raster wave.js",
           "size": 1115,
           "extension": ".js"
         },
         {
-          "path": "src\\demoscene\\vertical raster wave.js",
+          "path": "src/demoscene/vertical raster wave.js",
           "name": "vertical raster wave.js",
           "size": 1055,
           "extension": ".js"
@@ -2142,53 +2142,53 @@
       "size": 8147
     },
     {
-      "path": "src\\depth sorting",
+      "path": "src/depth sorting",
       "name": "depth sorting",
       "children": [
         {
-          "path": "src\\depth sorting\\3D depth sort.js",
+          "path": "src/depth sorting/3D depth sort.js",
           "name": "3D depth sort.js",
           "size": 6681,
           "extension": ".js"
         },
         {
-          "path": "src\\depth sorting\\bring to top.js",
+          "path": "src/depth sorting/bring to top.js",
           "name": "bring to top.js",
           "size": 737,
           "extension": ".js"
         },
         {
-          "path": "src\\depth sorting\\Depth Sorting.js",
+          "path": "src/depth sorting/Depth Sorting.js",
           "name": "Depth Sorting.js",
           "size": 1408,
           "extension": ".js"
         },
         {
-          "path": "src\\depth sorting\\get top object.js",
+          "path": "src/depth sorting/get top object.js",
           "name": "get top object.js",
           "size": 1776,
           "extension": ".js"
         },
         {
-          "path": "src\\depth sorting\\isometric blocks.js",
+          "path": "src/depth sorting/isometric blocks.js",
           "name": "isometric blocks.js",
           "size": 2437,
           "extension": ".js"
         },
         {
-          "path": "src\\depth sorting\\isometric map.js",
+          "path": "src/depth sorting/isometric map.js",
           "name": "isometric map.js",
           "size": 8110,
           "extension": ".js"
         },
         {
-          "path": "src\\depth sorting\\remove from display list.js",
+          "path": "src/depth sorting/remove from display list.js",
           "name": "remove from display list.js",
           "size": 1132,
           "extension": ".js"
         },
         {
-          "path": "src\\depth sorting\\z index.js",
+          "path": "src/depth sorting/z index.js",
           "name": "z index.js",
           "size": 1140,
           "extension": ".js"
@@ -2197,63 +2197,63 @@
       "size": 23421
     },
     {
-      "path": "src\\display",
+      "path": "src/display",
       "name": "display",
       "children": [
         {
-          "path": "src\\display\\align",
+          "path": "src/display/align",
           "name": "align",
           "children": [
             {
-              "path": "src\\display\\align\\in bottom center.js",
+              "path": "src/display/align/in bottom center.js",
               "name": "in bottom center.js",
               "size": 719,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\align\\in bottom left.js",
+              "path": "src/display/align/in bottom left.js",
               "name": "in bottom left.js",
               "size": 717,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\align\\in bottom right.js",
+              "path": "src/display/align/in bottom right.js",
               "name": "in bottom right.js",
               "size": 718,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\align\\in center.js",
+              "path": "src/display/align/in center.js",
               "name": "in center.js",
               "size": 713,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\align\\in left center.js",
+              "path": "src/display/align/in left center.js",
               "name": "in left center.js",
               "size": 717,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\align\\in right center.js",
+              "path": "src/display/align/in right center.js",
               "name": "in right center.js",
               "size": 718,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\align\\in top center.js",
+              "path": "src/display/align/in top center.js",
               "name": "in top center.js",
               "size": 716,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\align\\in top left.js",
+              "path": "src/display/align/in top left.js",
               "name": "in top left.js",
               "size": 714,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\align\\in top right.js",
+              "path": "src/display/align/in top right.js",
               "name": "in top right.js",
               "size": 715,
               "extension": ".js"
@@ -2262,35 +2262,35 @@
           "size": 6447
         },
         {
-          "path": "src\\display\\alpha",
+          "path": "src/display/alpha",
           "name": "alpha",
           "children": [
             {
-              "path": "src\\display\\alpha\\bottom alpha.js",
+              "path": "src/display/alpha/bottom alpha.js",
               "name": "bottom alpha.js",
               "size": 594,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\alpha\\single alpha.js",
+              "path": "src/display/alpha/single alpha.js",
               "name": "single alpha.js",
               "size": 448,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\alpha\\top alpha.js",
+              "path": "src/display/alpha/top alpha.js",
               "name": "top alpha.js",
               "size": 594,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\alpha\\top left alpha.js",
+              "path": "src/display/alpha/top left alpha.js",
               "name": "top left alpha.js",
               "size": 534,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\alpha\\tween alpha.js",
+              "path": "src/display/alpha/tween alpha.js",
               "name": "tween alpha.js",
               "size": 843,
               "extension": ".js"
@@ -2299,59 +2299,59 @@
           "size": 3013
         },
         {
-          "path": "src\\display\\blend modes",
+          "path": "src/display/blend modes",
           "name": "blend modes",
           "children": [
             {
-              "path": "src\\display\\blend modes\\blend mode tester.js",
+              "path": "src/display/blend modes/blend mode tester.js",
               "name": "blend mode tester.js",
               "size": 6504,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\blend modes\\circle cut out.js",
+              "path": "src/display/blend modes/circle cut out.js",
               "name": "circle cut out.js",
               "size": 784,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\blend modes\\custom blend mode with graphics.js",
+              "path": "src/display/blend modes/custom blend mode with graphics.js",
               "name": "custom blend mode with graphics.js",
               "size": 4145,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\blend modes\\custom blend mode.js",
+              "path": "src/display/blend modes/custom blend mode.js",
               "name": "custom blend mode.js",
               "size": 3642,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\blend modes\\custom separate blend mode.js",
+              "path": "src/display/blend modes/custom separate blend mode.js",
               "name": "custom separate blend mode.js",
               "size": 4169,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\blend modes\\difference.js",
+              "path": "src/display/blend modes/difference.js",
               "name": "difference.js",
               "size": 1700,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\blend modes\\graphics blend mode.js",
+              "path": "src/display/blend modes/graphics blend mode.js",
               "name": "graphics blend mode.js",
               "size": 976,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\blend modes\\overlay.js",
+              "path": "src/display/blend modes/overlay.js",
               "name": "overlay.js",
               "size": 1700,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\blend modes\\particle.js",
+              "path": "src/display/blend modes/particle.js",
               "name": "particle.js",
               "size": 1636,
               "extension": ".js"
@@ -2360,53 +2360,53 @@
           "size": 25256
         },
         {
-          "path": "src\\display\\color",
+          "path": "src/display/color",
           "name": "color",
           "children": [
             {
-              "path": "src\\display\\color\\brighten.js",
+              "path": "src/display/color/brighten.js",
               "name": "brighten.js",
               "size": 651,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\color\\darken.js",
+              "path": "src/display/color/darken.js",
               "name": "darken.js",
               "size": 647,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\color\\Hex String To Color.js",
+              "path": "src/display/color/Hex String To Color.js",
               "name": "Hex String To Color.js",
               "size": 580,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\color\\lighten.js",
+              "path": "src/display/color/lighten.js",
               "name": "lighten.js",
               "size": 649,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\color\\random color.js",
+              "path": "src/display/color/random color.js",
               "name": "random color.js",
               "size": 409,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\color\\random gray.js",
+              "path": "src/display/color/random gray.js",
               "name": "random gray.js",
               "size": 413,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\color\\RGB String To Color.js",
+              "path": "src/display/color/RGB String To Color.js",
               "name": "RGB String To Color.js",
               "size": 741,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\color\\Value To Color.js",
+              "path": "src/display/color/Value To Color.js",
               "name": "Value To Color.js",
               "size": 634,
               "extension": ".js"
@@ -2415,23 +2415,23 @@
           "size": 4724
         },
         {
-          "path": "src\\display\\effects",
+          "path": "src/display/effects",
           "name": "effects",
           "children": [
             {
-              "path": "src\\display\\effects\\flax.js",
+              "path": "src/display/effects/flax.js",
               "name": "flax.js",
               "size": 8416,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\effects\\fractal terrain.js",
+              "path": "src/display/effects/fractal terrain.js",
               "name": "fractal terrain.js",
               "size": 4197,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\effects\\terrain generator.js",
+              "path": "src/display/effects/terrain generator.js",
               "name": "terrain generator.js",
               "size": 7135,
               "extension": ".js"
@@ -2440,111 +2440,111 @@
           "size": 19748
         },
         {
-          "path": "src\\display\\masks",
+          "path": "src/display/masks",
           "name": "masks",
           "children": [
             {
-              "path": "src\\display\\masks\\BitmapMask Alpha.js",
+              "path": "src/display/masks/BitmapMask Alpha.js",
               "name": "BitmapMask Alpha.js",
               "size": 1161,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\masks\\BitmapMask BitmapFont.js",
+              "path": "src/display/masks/BitmapMask BitmapFont.js",
               "name": "BitmapMask BitmapFont.js",
               "size": 1737,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\masks\\BitmapMask BitmapFont2.js",
+              "path": "src/display/masks/BitmapMask BitmapFont2.js",
               "name": "BitmapMask BitmapFont2.js",
               "size": 1706,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\masks\\BitmapMask Example 2.js",
+              "path": "src/display/masks/BitmapMask Example 2.js",
               "name": "BitmapMask Example 2.js",
               "size": 1525,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\masks\\BitmapMask Example.js",
+              "path": "src/display/masks/BitmapMask Example.js",
               "name": "BitmapMask Example.js",
               "size": 1099,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\masks\\BitmapMask Masked Particles.js",
+              "path": "src/display/masks/BitmapMask Masked Particles.js",
               "name": "BitmapMask Masked Particles.js",
               "size": 1491,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\masks\\BitmapMask Particles.js",
+              "path": "src/display/masks/BitmapMask Particles.js",
               "name": "BitmapMask Particles.js",
               "size": 1460,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\masks\\BitmapMask Text Masking Text.js",
+              "path": "src/display/masks/BitmapMask Text Masking Text.js",
               "name": "BitmapMask Text Masking Text.js",
               "size": 1945,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\masks\\BitmapMask Text.js",
+              "path": "src/display/masks/BitmapMask Text.js",
               "name": "BitmapMask Text.js",
               "size": 1247,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\masks\\BitmapMask Text2.js",
+              "path": "src/display/masks/BitmapMask Text2.js",
               "name": "BitmapMask Text2.js",
               "size": 1247,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\masks\\Camera Inversed Mask Test 1.js",
+              "path": "src/display/masks/Camera Inversed Mask Test 1.js",
               "name": "Camera Inversed Mask Test 1.js",
               "size": 3390,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\masks\\Camera Mask Test 1.js",
+              "path": "src/display/masks/Camera Mask Test 1.js",
               "name": "Camera Mask Test 1.js",
               "size": 2595,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\masks\\Camera Mask Test 2.js",
+              "path": "src/display/masks/Camera Mask Test 2.js",
               "name": "Camera Mask Test 2.js",
               "size": 2459,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\masks\\Camera Mask Test 3.js",
+              "path": "src/display/masks/Camera Mask Test 3.js",
               "name": "Camera Mask Test 3.js",
               "size": 4252,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\masks\\Camera Mask Test 4.js",
+              "path": "src/display/masks/Camera Mask Test 4.js",
               "name": "Camera Mask Test 4.js",
               "size": 2380,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\masks\\Camera Mask Test 5.js",
+              "path": "src/display/masks/Camera Mask Test 5.js",
               "name": "Camera Mask Test 5.js",
               "size": 2104,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\masks\\component",
+              "path": "src/display/masks/component",
               "name": "component",
               "children": [
                 {
-                  "path": "src\\display\\masks\\component\\add mask to sprite.js",
+                  "path": "src/display/masks/component/add mask to sprite.js",
                   "name": "add mask to sprite.js",
                   "size": 994,
                   "extension": ".js"
@@ -2553,53 +2553,53 @@
               "size": 994
             },
             {
-              "path": "src\\display\\masks\\Container Mask Test 1.js",
+              "path": "src/display/masks/Container Mask Test 1.js",
               "name": "Container Mask Test 1.js",
               "size": 2892,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\masks\\Container Mask Test 2.js",
+              "path": "src/display/masks/Container Mask Test 2.js",
               "name": "Container Mask Test 2.js",
               "size": 4064,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\masks\\Container Mask Test 3.js",
+              "path": "src/display/masks/Container Mask Test 3.js",
               "name": "Container Mask Test 3.js",
               "size": 4414,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\masks\\flickering spotlight.js",
+              "path": "src/display/masks/flickering spotlight.js",
               "name": "flickering spotlight.js",
               "size": 1064,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\masks\\geometry mask",
+              "path": "src/display/masks/geometry mask",
               "name": "geometry mask",
               "children": [
                 {
-                  "path": "src\\display\\masks\\geometry mask\\graphics mask.js",
+                  "path": "src/display/masks/geometry mask/graphics mask.js",
                   "name": "graphics mask.js",
                   "size": 3334,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\display\\masks\\geometry mask\\image mask arc.js",
+                  "path": "src/display/masks/geometry mask/image mask arc.js",
                   "name": "image mask arc.js",
                   "size": 868,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\display\\masks\\geometry mask\\image mask.js",
+                  "path": "src/display/masks/geometry mask/image mask.js",
                   "name": "image mask.js",
                   "size": 991,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\display\\masks\\geometry mask\\multiple image mask.js",
+                  "path": "src/display/masks/geometry mask/multiple image mask.js",
                   "name": "multiple image mask.js",
                   "size": 1454,
                   "extension": ".js"
@@ -2608,43 +2608,43 @@
               "size": 6647
             },
             {
-              "path": "src\\display\\masks\\GeometryMask Example.js",
+              "path": "src/display/masks/GeometryMask Example.js",
               "name": "GeometryMask Example.js",
               "size": 2119,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\masks\\GeometryMask Example0.js",
+              "path": "src/display/masks/GeometryMask Example0.js",
               "name": "GeometryMask Example0.js",
               "size": 2639,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\masks\\logo shine.js",
+              "path": "src/display/masks/logo shine.js",
               "name": "logo shine.js",
               "size": 3609,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\masks\\magnify glass.js",
+              "path": "src/display/masks/magnify glass.js",
               "name": "magnify glass.js",
               "size": 1137,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\masks\\Mask Perf Test.js",
+              "path": "src/display/masks/Mask Perf Test.js",
               "name": "Mask Perf Test.js",
               "size": 2703,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\masks\\spotlight rect.js",
+              "path": "src/display/masks/spotlight rect.js",
               "name": "spotlight rect.js",
               "size": 885,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\masks\\spotlight.js",
+              "path": "src/display/masks/spotlight.js",
               "name": "spotlight.js",
               "size": 926,
               "extension": ".js"
@@ -2653,53 +2653,53 @@
           "size": 65891
         },
         {
-          "path": "src\\display\\shaders",
+          "path": "src/display/shaders",
           "name": "shaders",
           "children": [
             {
-              "path": "src\\display\\shaders\\shader test 1.js",
+              "path": "src/display/shaders/shader test 1.js",
               "name": "shader test 1.js",
               "size": 9952,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\shaders\\shader test 2.js",
+              "path": "src/display/shaders/shader test 2.js",
               "name": "shader test 2.js",
               "size": 4036,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\shaders\\shader test 3.js",
+              "path": "src/display/shaders/shader test 3.js",
               "name": "shader test 3.js",
               "size": 2495,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\shaders\\shader test 4.js",
+              "path": "src/display/shaders/shader test 4.js",
               "name": "shader test 4.js",
               "size": 6689,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\shaders\\shader test 5.js",
+              "path": "src/display/shaders/shader test 5.js",
               "name": "shader test 5.js",
               "size": 16473,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\shaders\\shader test 6.js",
+              "path": "src/display/shaders/shader test 6.js",
               "name": "shader test 6.js",
               "size": 1273,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\shaders\\shader test 7.js",
+              "path": "src/display/shaders/shader test 7.js",
               "name": "shader test 7.js",
               "size": 513,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\shaders\\shader test 8.js",
+              "path": "src/display/shaders/shader test 8.js",
               "name": "shader test 8.js",
               "size": 972,
               "extension": ".js"
@@ -2708,89 +2708,89 @@
           "size": 42403
         },
         {
-          "path": "src\\display\\tint",
+          "path": "src/display/tint",
           "name": "tint",
           "children": [
             {
-              "path": "src\\display\\tint\\atlas frame tint.js",
+              "path": "src/display/tint/atlas frame tint.js",
               "name": "atlas frame tint.js",
               "size": 835,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\tint\\corner tint.js",
+              "path": "src/display/tint/corner tint.js",
               "name": "corner tint.js",
               "size": 924,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\tint\\multiple images.js",
+              "path": "src/display/tint/multiple images.js",
               "name": "multiple images.js",
               "size": 512,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\tint\\per vertex tint.js",
+              "path": "src/display/tint/per vertex tint.js",
               "name": "per vertex tint.js",
               "size": 842,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\tint\\pixel wave.js",
+              "path": "src/display/tint/pixel wave.js",
               "name": "pixel wave.js",
               "size": 1947,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\tint\\rainbow text.js",
+              "path": "src/display/tint/rainbow text.js",
               "name": "rainbow text.js",
               "size": 1053,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\tint\\rasters.js",
+              "path": "src/display/tint/rasters.js",
               "name": "rasters.js",
               "size": 1119,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\tint\\single color tint.js",
+              "path": "src/display/tint/single color tint.js",
               "name": "single color tint.js",
               "size": 731,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\tint\\text tint.js",
+              "path": "src/display/tint/text tint.js",
               "name": "text tint.js",
               "size": 671,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\tint\\tile sprite tint.js",
+              "path": "src/display/tint/tile sprite tint.js",
               "name": "tile sprite tint.js",
               "size": 1050,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\tint\\tint and alpha.js",
+              "path": "src/display/tint/tint and alpha.js",
               "name": "tint and alpha.js",
               "size": 817,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\tint\\tint fill effect.js",
+              "path": "src/display/tint/tint fill effect.js",
               "name": "tint fill effect.js",
               "size": 1036,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\tint\\tint fill.js",
+              "path": "src/display/tint/tint fill.js",
               "name": "tint fill.js",
               "size": 1766,
               "extension": ".js"
             },
             {
-              "path": "src\\display\\tint\\tween tint.js",
+              "path": "src/display/tint/tween tint.js",
               "name": "tween tint.js",
               "size": 713,
               "extension": ".js"
@@ -2802,29 +2802,29 @@
       "size": 181498
     },
     {
-      "path": "src\\dwitter",
+      "path": "src/dwitter",
       "name": "dwitter",
       "children": [
         {
-          "path": "src\\dwitter\\5475.js",
+          "path": "src/dwitter/5475.js",
           "name": "5475.js",
           "size": 1111,
           "extension": ".js"
         },
         {
-          "path": "src\\dwitter\\5479.js",
+          "path": "src/dwitter/5479.js",
           "name": "5479.js",
           "size": 1127,
           "extension": ".js"
         },
         {
-          "path": "src\\dwitter\\5500.js",
+          "path": "src/dwitter/5500.js",
           "name": "5500.js",
           "size": 1125,
           "extension": ".js"
         },
         {
-          "path": "src\\dwitter\\test.js",
+          "path": "src/dwitter/test.js",
           "name": "test.js",
           "size": 1140,
           "extension": ".js"
@@ -2833,59 +2833,59 @@
       "size": 4503
     },
     {
-      "path": "src\\events",
+      "path": "src/events",
       "name": "events",
       "children": [
         {
-          "path": "src\\events\\create event emitter.js",
+          "path": "src/events/create event emitter.js",
           "name": "create event emitter.js",
           "size": 769,
           "extension": ".js"
         },
         {
-          "path": "src\\events\\emit scene event.js",
+          "path": "src/events/emit scene event.js",
           "name": "emit scene event.js",
           "size": 662,
           "extension": ".js"
         },
         {
-          "path": "src\\events\\emit using symbols.js",
+          "path": "src/events/emit using symbols.js",
           "name": "emit using symbols.js",
           "size": 1296,
           "extension": ".js"
         },
         {
-          "path": "src\\events\\event arguments.js",
+          "path": "src/events/event arguments.js",
           "name": "event arguments.js",
           "size": 665,
           "extension": ".js"
         },
         {
-          "path": "src\\events\\game object events.js",
+          "path": "src/events/game object events.js",
           "name": "game object events.js",
           "size": 751,
           "extension": ".js"
         },
         {
-          "path": "src\\events\\listen to game object event.js",
+          "path": "src/events/listen to game object event.js",
           "name": "listen to game object event.js",
           "size": 1829,
           "extension": ".js"
         },
         {
-          "path": "src\\events\\once event.js",
+          "path": "src/events/once event.js",
           "name": "once event.js",
           "size": 818,
           "extension": ".js"
         },
         {
-          "path": "src\\events\\turn off anonymous event handler.js",
+          "path": "src/events/turn off anonymous event handler.js",
           "name": "turn off anonymous event handler.js",
           "size": 925,
           "extension": ".js"
         },
         {
-          "path": "src\\events\\turn off event handler.js",
+          "path": "src/events/turn off event handler.js",
           "name": "turn off event handler.js",
           "size": 871,
           "extension": ".js"
@@ -2894,101 +2894,101 @@
       "size": 8586
     },
     {
-      "path": "src\\game config",
+      "path": "src/game config",
       "name": "game config",
       "children": [
         {
-          "path": "src\\game config\\banner colors.js",
+          "path": "src/game config/banner colors.js",
           "name": "banner colors.js",
           "size": 1001,
           "extension": ".js"
         },
         {
-          "path": "src\\game config\\custom canvas.js",
+          "path": "src/game config/custom canvas.js",
           "name": "custom canvas.js",
           "size": 689,
           "extension": ".js"
         },
         {
-          "path": "src\\game config\\custom webgl canvas.js",
+          "path": "src/game config/custom webgl canvas.js",
           "name": "custom webgl canvas.js",
           "size": 1045,
           "extension": ".js"
         },
         {
-          "path": "src\\game config\\custom webgl2 canvas.js",
+          "path": "src/game config/custom webgl2 canvas.js",
           "name": "custom webgl2 canvas.js",
           "size": 1046,
           "extension": ".js"
         },
         {
-          "path": "src\\game config\\game destroy with multi scenes.js",
+          "path": "src/game config/game destroy with multi scenes.js",
           "name": "game destroy with multi scenes.js",
           "size": 1709,
           "extension": ".js"
         },
         {
-          "path": "src\\game config\\game destroy.js",
+          "path": "src/game config/game destroy.js",
           "name": "game destroy.js",
           "size": 1088,
           "extension": ".js"
         },
         {
-          "path": "src\\game config\\game rng.js",
+          "path": "src/game config/game rng.js",
           "name": "game rng.js",
           "size": 1105,
           "extension": ".js"
         },
         {
-          "path": "src\\game config\\game title.js",
+          "path": "src/game config/game title.js",
           "name": "game title.js",
           "size": 614,
           "extension": ".js"
         },
         {
-          "path": "src\\game config\\game url.js",
+          "path": "src/game config/game url.js",
           "name": "game url.js",
           "size": 755,
           "extension": ".js"
         },
         {
-          "path": "src\\game config\\game version.js",
+          "path": "src/game config/game version.js",
           "name": "game version.js",
           "size": 747,
           "extension": ".js"
         },
         {
-          "path": "src\\game config\\headless renderer.js",
+          "path": "src/game config/headless renderer.js",
           "name": "headless renderer.js",
           "size": 488,
           "extension": ".js"
         },
         {
-          "path": "src\\game config\\hide banner.js",
+          "path": "src/game config/hide banner.js",
           "name": "hide banner.js",
           "size": 560,
           "extension": ".js"
         },
         {
-          "path": "src\\game config\\hide phaser from banner.js",
+          "path": "src/game config/hide phaser from banner.js",
           "name": "hide phaser from banner.js",
           "size": 753,
           "extension": ".js"
         },
         {
-          "path": "src\\game config\\multiple game instances.js",
+          "path": "src/game config/multiple game instances.js",
           "name": "multiple game instances.js",
           "size": 1944,
           "extension": ".js"
         },
         {
-          "path": "src\\game config\\round pixels.js",
+          "path": "src/game config/round pixels.js",
           "name": "round pixels.js",
           "size": 761,
           "extension": ".js"
         },
         {
-          "path": "src\\game config\\transparent.js",
+          "path": "src/game config/transparent.js",
           "name": "transparent.js",
           "size": 663,
           "extension": ".js"
@@ -2997,61 +2997,61 @@
       "size": 14968
     },
     {
-      "path": "src\\game objects",
+      "path": "src/game objects",
       "name": "game objects",
       "children": [
         {
-          "path": "src\\game objects\\bitmaptext",
+          "path": "src/game objects/bitmaptext",
           "name": "bitmaptext",
           "children": [
             {
-              "path": "src\\game objects\\bitmaptext\\dynamic",
+              "path": "src/game objects/bitmaptext/dynamic",
               "name": "dynamic",
               "children": [
                 {
-                  "path": "src\\game objects\\bitmaptext\\dynamic\\canvas text.js",
+                  "path": "src/game objects/bitmaptext/dynamic/canvas text.js",
                   "name": "canvas text.js",
                   "size": 1933,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\dynamic\\display callback index effect.js",
+                  "path": "src/game objects/bitmaptext/dynamic/display callback index effect.js",
                   "name": "display callback index effect.js",
                   "size": 1755,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\dynamic\\display callback rotation effect.js",
+                  "path": "src/game objects/bitmaptext/dynamic/display callback rotation effect.js",
                   "name": "display callback rotation effect.js",
                   "size": 1682,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\dynamic\\display callback scale effect.js",
+                  "path": "src/game objects/bitmaptext/dynamic/display callback scale effect.js",
                   "name": "display callback scale effect.js",
                   "size": 1052,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\dynamic\\display callback wibble effect.js",
+                  "path": "src/game objects/bitmaptext/dynamic/display callback wibble effect.js",
                   "name": "display callback wibble effect.js",
                   "size": 968,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\dynamic\\text follow path.js",
+                  "path": "src/game objects/bitmaptext/dynamic/text follow path.js",
                   "name": "text follow path.js",
                   "size": 1299,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\dynamic\\tinted text.js",
+                  "path": "src/game objects/bitmaptext/dynamic/tinted text.js",
                   "name": "tinted text.js",
                   "size": 962,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\dynamic\\vertical scroller.js",
+                  "path": "src/game objects/bitmaptext/dynamic/vertical scroller.js",
                   "name": "vertical scroller.js",
                   "size": 2551,
                   "extension": ".js"
@@ -3060,47 +3060,47 @@
               "size": 12202
             },
             {
-              "path": "src\\game objects\\bitmaptext\\retro font",
+              "path": "src/game objects/bitmaptext/retro font",
               "name": "retro font",
               "children": [
                 {
-                  "path": "src\\game objects\\bitmaptext\\retro font\\retro text 1.js",
+                  "path": "src/game objects/bitmaptext/retro font/retro text 1.js",
                   "name": "retro text 1.js",
                   "size": 918,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\retro font\\retro text 2.js",
+                  "path": "src/game objects/bitmaptext/retro font/retro text 2.js",
                   "name": "retro text 2.js",
                   "size": 909,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\retro font\\retro text mega scroll.js",
+                  "path": "src/game objects/bitmaptext/retro font/retro text mega scroll.js",
                   "name": "retro text mega scroll.js",
                   "size": 1836,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\retro font\\retro text scroll callback.js",
+                  "path": "src/game objects/bitmaptext/retro font/retro text scroll callback.js",
                   "name": "retro text scroll callback.js",
                   "size": 1791,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\retro font\\retro text scroll.js",
+                  "path": "src/game objects/bitmaptext/retro font/retro text scroll.js",
                   "name": "retro text scroll.js",
                   "size": 1472,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\retro font\\scrolling retro text.js",
+                  "path": "src/game objects/bitmaptext/retro font/scrolling retro text.js",
                   "name": "scrolling retro text.js",
                   "size": 3101,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\retro font\\tinted retro text.js",
+                  "path": "src/game objects/bitmaptext/retro font/tinted retro text.js",
                   "name": "tinted retro text.js",
                   "size": 1223,
                   "extension": ".js"
@@ -3109,113 +3109,113 @@
               "size": 11250
             },
             {
-              "path": "src\\game objects\\bitmaptext\\static",
+              "path": "src/game objects/bitmaptext/static",
               "name": "static",
               "children": [
                 {
-                  "path": "src\\game objects\\bitmaptext\\static\\bitmaptext blend mode.js",
+                  "path": "src/game objects/bitmaptext/static/bitmaptext blend mode.js",
                   "name": "bitmaptext blend mode.js",
                   "size": 954,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\static\\bitmaptext rotation.js",
+                  "path": "src/game objects/bitmaptext/static/bitmaptext rotation.js",
                   "name": "bitmaptext rotation.js",
                   "size": 1026,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\static\\bitmaptext scale.js",
+                  "path": "src/game objects/bitmaptext/static/bitmaptext scale.js",
                   "name": "bitmaptext scale.js",
                   "size": 779,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\static\\bitmaptext-atlas.js",
+                  "path": "src/game objects/bitmaptext/static/bitmaptext-atlas.js",
                   "name": "bitmaptext-atlas.js",
                   "size": 1488,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\static\\bitmaptext-canvas.js",
+                  "path": "src/game objects/bitmaptext/static/bitmaptext-canvas.js",
                   "name": "bitmaptext-canvas.js",
                   "size": 1250,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\static\\bitmaptext.js",
+                  "path": "src/game objects/bitmaptext/static/bitmaptext.js",
                   "name": "bitmaptext.js",
                   "size": 1038,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\static\\change font size.js",
+                  "path": "src/game objects/bitmaptext/static/change font size.js",
                   "name": "change font size.js",
                   "size": 733,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\static\\change font.js",
+                  "path": "src/game objects/bitmaptext/static/change font.js",
                   "name": "change font.js",
                   "size": 1365,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\static\\get text size multiline.js",
+                  "path": "src/game objects/bitmaptext/static/get text size multiline.js",
                   "name": "get text size multiline.js",
                   "size": 925,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\static\\get text size scaled.js",
+                  "path": "src/game objects/bitmaptext/static/get text size scaled.js",
                   "name": "get text size scaled.js",
                   "size": 1283,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\static\\get text size.js",
+                  "path": "src/game objects/bitmaptext/static/get text size.js",
                   "name": "get text size.js",
                   "size": 1470,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\static\\large-text.js",
+                  "path": "src/game objects/bitmaptext/static/large-text.js",
                   "name": "large-text.js",
                   "size": 1266,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\static\\multi line alignment.js",
+                  "path": "src/game objects/bitmaptext/static/multi line alignment.js",
                   "name": "multi line alignment.js",
                   "size": 1316,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\static\\multi line.js",
+                  "path": "src/game objects/bitmaptext/static/multi line.js",
                   "name": "multi line.js",
                   "size": 801,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\static\\padding.js",
+                  "path": "src/game objects/bitmaptext/static/padding.js",
                   "name": "padding.js",
                   "size": 898,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\static\\text origin.js",
+                  "path": "src/game objects/bitmaptext/static/text origin.js",
                   "name": "text origin.js",
                   "size": 1381,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\static\\tinted text.js",
+                  "path": "src/game objects/bitmaptext/static/tinted text.js",
                   "name": "tinted text.js",
                   "size": 603,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\bitmaptext\\static\\width and height.js",
+                  "path": "src/game objects/bitmaptext/static/width and height.js",
                   "name": "width and height.js",
                   "size": 1198,
                   "extension": ".js"
@@ -3227,107 +3227,107 @@
           "size": 43226
         },
         {
-          "path": "src\\game objects\\blitter",
+          "path": "src/game objects/blitter",
           "name": "blitter",
           "children": [
             {
-              "path": "src\\game objects\\blitter\\benchmark test 1.js",
+              "path": "src/game objects/blitter/benchmark test 1.js",
               "name": "benchmark test 1.js",
               "size": 1004,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\blitter\\benchmark test 2.js",
+              "path": "src/game objects/blitter/benchmark test 2.js",
               "name": "benchmark test 2.js",
               "size": 1134,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\blitter\\benchmark test 3.js",
+              "path": "src/game objects/blitter/benchmark test 3.js",
               "name": "benchmark test 3.js",
               "size": 2761,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\blitter\\blitter alpha.js",
+              "path": "src/game objects/blitter/blitter alpha.js",
               "name": "blitter alpha.js",
               "size": 597,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\blitter\\blitter camera test canvas.js",
+              "path": "src/game objects/blitter/blitter camera test canvas.js",
               "name": "blitter camera test canvas.js",
               "size": 1350,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\blitter\\blitter camera test.js",
+              "path": "src/game objects/blitter/blitter camera test.js",
               "name": "blitter camera test.js",
               "size": 1350,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\blitter\\blitter global alpha.js",
+              "path": "src/game objects/blitter/blitter global alpha.js",
               "name": "blitter global alpha.js",
               "size": 530,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\blitter\\bob frame object.js",
+              "path": "src/game objects/blitter/bob frame object.js",
               "name": "bob frame object.js",
               "size": 978,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\blitter\\bobs using a multi atlas.js",
+              "path": "src/game objects/blitter/bobs using a multi atlas.js",
               "name": "bobs using a multi atlas.js",
               "size": 915,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\blitter\\canvas benchmark 1.js",
+              "path": "src/game objects/blitter/canvas benchmark 1.js",
               "name": "canvas benchmark 1.js",
               "size": 2760,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\blitter\\create from callback.js",
+              "path": "src/game objects/blitter/create from callback.js",
               "name": "create from callback.js",
               "size": 659,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\blitter\\multiple atlas frame bobs.js",
+              "path": "src/game objects/blitter/multiple atlas frame bobs.js",
               "name": "multiple atlas frame bobs.js",
               "size": 806,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\blitter\\multiple bobs.js",
+              "path": "src/game objects/blitter/multiple bobs.js",
               "name": "multiple bobs.js",
               "size": 485,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\blitter\\single atlas frame bob.js",
+              "path": "src/game objects/blitter/single atlas frame bob.js",
               "name": "single atlas frame bob.js",
               "size": 445,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\blitter\\single image bob.js",
+              "path": "src/game objects/blitter/single image bob.js",
               "name": "single image bob.js",
               "size": 485,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\blitter\\tween test 1.js",
+              "path": "src/game objects/blitter/tween test 1.js",
               "name": "tween test 1.js",
               "size": 2074,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\blitter\\twist scroller.js",
+              "path": "src/game objects/blitter/twist scroller.js",
               "name": "twist scroller.js",
               "size": 13397,
               "extension": ".js"
@@ -3336,305 +3336,305 @@
           "size": 31730
         },
         {
-          "path": "src\\game objects\\container",
+          "path": "src/game objects/container",
           "name": "container",
           "children": [
             {
-              "path": "src\\game objects\\container\\add array of sprites at index.js",
+              "path": "src/game objects/container/add array of sprites at index.js",
               "name": "add array of sprites at index.js",
               "size": 1251,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\add array of sprites to container.js",
+              "path": "src/game objects/container/add array of sprites to container.js",
               "name": "add array of sprites to container.js",
               "size": 1284,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\add emitter to container.js",
+              "path": "src/game objects/container/add emitter to container.js",
               "name": "add emitter to container.js",
               "size": 931,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\add sprite to container.js",
+              "path": "src/game objects/container/add sprite to container.js",
               "name": "add sprite to container.js",
               "size": 1186,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\add tilesprite to container.js",
+              "path": "src/game objects/container/add tilesprite to container.js",
               "name": "add tilesprite to container.js",
               "size": 972,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\animation test.js",
+              "path": "src/game objects/container/animation test.js",
               "name": "animation test.js",
               "size": 1017,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\arcade physics body test.js",
+              "path": "src/game objects/container/arcade physics body test.js",
               "name": "arcade physics body test.js",
               "size": 1316,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\arcade physics sprite test.js",
+              "path": "src/game objects/container/arcade physics sprite test.js",
               "name": "arcade physics sprite test.js",
               "size": 1081,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\camera transform test.js",
+              "path": "src/game objects/container/camera transform test.js",
               "name": "camera transform test.js",
               "size": 3946,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\child blend mode.js",
+              "path": "src/game objects/container/child blend mode.js",
               "name": "child blend mode.js",
               "size": 1075,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\child order.js",
+              "path": "src/game objects/container/child order.js",
               "name": "child order.js",
               "size": 700,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\container alpha.js",
+              "path": "src/game objects/container/container alpha.js",
               "name": "container alpha.js",
               "size": 1259,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\container and camera zoom.js",
+              "path": "src/game objects/container/container and camera zoom.js",
               "name": "container and camera zoom.js",
               "size": 2417,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\container and child input.js",
+              "path": "src/game objects/container/container and child input.js",
               "name": "container and child input.js",
               "size": 1448,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\container as mask.js",
+              "path": "src/game objects/container/container as mask.js",
               "name": "container as mask.js",
               "size": 3953,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\container depth.js",
+              "path": "src/game objects/container/container depth.js",
               "name": "container depth.js",
               "size": 1001,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\container hitarea from size.js",
+              "path": "src/game objects/container/container hitarea from size.js",
               "name": "container hitarea from size.js",
               "size": 875,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\container hitarea.js",
+              "path": "src/game objects/container/container hitarea.js",
               "name": "container hitarea.js",
               "size": 1587,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\container ik.js",
+              "path": "src/game objects/container/container ik.js",
               "name": "container ik.js",
               "size": 2612,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\container input test.js",
+              "path": "src/game objects/container/container input test.js",
               "name": "container input test.js",
               "size": 1409,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\container mask.js",
+              "path": "src/game objects/container/container mask.js",
               "name": "container mask.js",
               "size": 3738,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\container scrollfactor.js",
+              "path": "src/game objects/container/container scrollfactor.js",
               "name": "container scrollfactor.js",
               "size": 1733,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\create container.js",
+              "path": "src/game objects/container/create container.js",
               "name": "create container.js",
               "size": 977,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\draggable container.js",
+              "path": "src/game objects/container/draggable container.js",
               "name": "draggable container.js",
               "size": 1069,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\get bounds test 1.js",
+              "path": "src/game objects/container/get bounds test 1.js",
               "name": "get bounds test 1.js",
               "size": 1770,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\impact physics body test.js",
+              "path": "src/game objects/container/impact physics body test.js",
               "name": "impact physics body test.js",
               "size": 1271,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\impact physics sprite test.js",
+              "path": "src/game objects/container/impact physics sprite test.js",
               "name": "impact physics sprite test.js",
               "size": 1177,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\input overlap test.js",
+              "path": "src/game objects/container/input overlap test.js",
               "name": "input overlap test.js",
               "size": 2209,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\matter physics body test camera.js",
+              "path": "src/game objects/container/matter physics body test camera.js",
               "name": "matter physics body test camera.js",
               "size": 1432,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\matter physics body test.js",
+              "path": "src/game objects/container/matter physics body test.js",
               "name": "matter physics body test.js",
               "size": 1259,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\matter physics sprite test.js",
+              "path": "src/game objects/container/matter physics sprite test.js",
               "name": "matter physics sprite test.js",
               "size": 1101,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\multi camera input test.js",
+              "path": "src/game objects/container/multi camera input test.js",
               "name": "multi camera input test.js",
               "size": 5826,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\multi container depth test.js",
+              "path": "src/game objects/container/multi container depth test.js",
               "name": "multi container depth test.js",
               "size": 1239,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\multiple non exclusive containers.js",
+              "path": "src/game objects/container/multiple non exclusive containers.js",
               "name": "multiple non exclusive containers.js",
               "size": 2224,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\nested container input test.js",
+              "path": "src/game objects/container/nested container input test.js",
               "name": "nested container input test.js",
               "size": 889,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\nested container visibility.js",
+              "path": "src/game objects/container/nested container visibility.js",
               "name": "nested container visibility.js",
               "size": 760,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\nested get bounds test.js",
+              "path": "src/game objects/container/nested get bounds test.js",
               "name": "nested get bounds test.js",
               "size": 1111,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\nested input test.js",
+              "path": "src/game objects/container/nested input test.js",
               "name": "nested input test.js",
               "size": 1279,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\non exclusive containers.js",
+              "path": "src/game objects/container/non exclusive containers.js",
               "name": "non exclusive containers.js",
               "size": 1374,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\parent matrix.js",
+              "path": "src/game objects/container/parent matrix.js",
               "name": "parent matrix.js",
               "size": 2586,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\rotated input test.js",
+              "path": "src/game objects/container/rotated input test.js",
               "name": "rotated input test.js",
               "size": 1189,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\rotation.js",
+              "path": "src/game objects/container/rotation.js",
               "name": "rotation.js",
               "size": 732,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\scaled input test.js",
+              "path": "src/game objects/container/scaled input test.js",
               "name": "scaled input test.js",
               "size": 819,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\text and sprite test.js",
+              "path": "src/game objects/container/text and sprite test.js",
               "name": "text and sprite test.js",
               "size": 959,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\twirl 1.js",
+              "path": "src/game objects/container/twirl 1.js",
               "name": "twirl 1.js",
               "size": 2224,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\twirl 2.js",
+              "path": "src/game objects/container/twirl 2.js",
               "name": "twirl 2.js",
               "size": 2291,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\twirl 3.js",
+              "path": "src/game objects/container/twirl 3.js",
               "name": "twirl 3.js",
               "size": 2299,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\twirl 4.js",
+              "path": "src/game objects/container/twirl 4.js",
               "name": "twirl 4.js",
               "size": 2090,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\twirl 5.js",
+              "path": "src/game objects/container/twirl 5.js",
               "name": "twirl 5.js",
               "size": 2375,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\container\\twirl 6.js",
+              "path": "src/game objects/container/twirl 6.js",
               "name": "twirl 6.js",
               "size": 2131,
               "extension": ".js"
@@ -3643,113 +3643,113 @@
           "size": 83453
         },
         {
-          "path": "src\\game objects\\dom element",
+          "path": "src/game objects/dom element",
           "name": "dom element",
           "children": [
             {
-              "path": "src\\game objects\\dom element\\blend mode.js",
+              "path": "src/game objects/dom element/blend mode.js",
               "name": "blend mode.js",
               "size": 1642,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\dom element\\css style object.js",
+              "path": "src/game objects/dom element/css style object.js",
               "name": "css style object.js",
               "size": 901,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\dom element\\css text.js",
+              "path": "src/game objects/dom element/css text.js",
               "name": "css text.js",
               "size": 821,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\dom element\\cursors test.js",
+              "path": "src/game objects/dom element/cursors test.js",
               "name": "cursors test.js",
               "size": 1279,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\dom element\\div depth.js",
+              "path": "src/game objects/dom element/div depth.js",
               "name": "div depth.js",
               "size": 1216,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\dom element\\div position test 1.js",
+              "path": "src/game objects/dom element/div position test 1.js",
               "name": "div position test 1.js",
               "size": 920,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\dom element\\div position test 2.js",
+              "path": "src/game objects/dom element/div position test 2.js",
               "name": "div position test 2.js",
               "size": 949,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\dom element\\div position test 3.js",
+              "path": "src/game objects/dom element/div position test 3.js",
               "name": "div position test 3.js",
               "size": 949,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\dom element\\div position test 4.js",
+              "path": "src/game objects/dom element/div position test 4.js",
               "name": "div position test 4.js",
               "size": 1002,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\dom element\\div position test 5.js",
+              "path": "src/game objects/dom element/div position test 5.js",
               "name": "div position test 5.js",
               "size": 1000,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\dom element\\form input.js",
+              "path": "src/game objects/dom element/form input.js",
               "name": "form input.js",
               "size": 2218,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\dom element\\input test.js",
+              "path": "src/game objects/dom element/input test.js",
               "name": "input test.js",
               "size": 2436,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\dom element\\move camera.js",
+              "path": "src/game objects/dom element/move camera.js",
               "name": "move camera.js",
               "size": 2779,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\dom element\\physics element.js",
+              "path": "src/game objects/dom element/physics element.js",
               "name": "physics element.js",
               "size": 1251,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\dom element\\rotate3d.js",
+              "path": "src/game objects/dom element/rotate3d.js",
               "name": "rotate3d.js",
               "size": 1020,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\dom element\\skew.js",
+              "path": "src/game objects/dom element/skew.js",
               "name": "skew.js",
               "size": 922,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\dom element\\using a div.js",
+              "path": "src/game objects/dom element/using a div.js",
               "name": "using a div.js",
               "size": 1423,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\dom element\\video element.js",
+              "path": "src/game objects/dom element/video element.js",
               "name": "video element.js",
               "size": 798,
               "extension": ".js"
@@ -3758,327 +3758,327 @@
           "size": 23526
         },
         {
-          "path": "src\\game objects\\graphics",
+          "path": "src/game objects/graphics",
           "name": "graphics",
           "children": [
             {
-              "path": "src\\game objects\\graphics\\arc stroke.js",
+              "path": "src/game objects/graphics/arc stroke.js",
               "name": "arc stroke.js",
               "size": 708,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\arc.js",
+              "path": "src/game objects/graphics/arc.js",
               "name": "arc.js",
               "size": 677,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\atari lines.js",
+              "path": "src/game objects/graphics/atari lines.js",
               "name": "atari lines.js",
               "size": 4693,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\circle overlap.js",
+              "path": "src/game objects/graphics/circle overlap.js",
               "name": "circle overlap.js",
               "size": 923,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\circle spin.js",
+              "path": "src/game objects/graphics/circle spin.js",
               "name": "circle spin.js",
               "size": 1825,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\circles test.js",
+              "path": "src/game objects/graphics/circles test.js",
               "name": "circles test.js",
               "size": 903,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\draw triangles.js",
+              "path": "src/game objects/graphics/draw triangles.js",
               "name": "draw triangles.js",
               "size": 4573,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\fill rect.js",
+              "path": "src/game objects/graphics/fill rect.js",
               "name": "fill rect.js",
               "size": 495,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\fill rounded rectangle.js",
+              "path": "src/game objects/graphics/fill rounded rectangle.js",
               "name": "fill rounded rectangle.js",
               "size": 600,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\generate texture test.js",
+              "path": "src/game objects/graphics/generate texture test.js",
               "name": "generate texture test.js",
               "size": 433,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\generate texture to blitter.js",
+              "path": "src/game objects/graphics/generate texture to blitter.js",
               "name": "generate texture to blitter.js",
               "size": 4188,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\generate texture to sprite.js",
+              "path": "src/game objects/graphics/generate texture to sprite.js",
               "name": "generate texture to sprite.js",
               "size": 1418,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\Graphics Rendering.js",
+              "path": "src/game objects/graphics/Graphics Rendering.js",
               "name": "Graphics Rendering.js",
               "size": 1423,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\graphics styles.js",
+              "path": "src/game objects/graphics/graphics styles.js",
               "name": "graphics styles.js",
               "size": 449,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\health bars demo.js",
+              "path": "src/game objects/graphics/health bars demo.js",
               "name": "health bars demo.js",
               "size": 6552,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\line rendering.js",
+              "path": "src/game objects/graphics/line rendering.js",
               "name": "line rendering.js",
               "size": 1916,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\line thickness.js",
+              "path": "src/game objects/graphics/line thickness.js",
               "name": "line thickness.js",
               "size": 642,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\Many Line Stars.js",
+              "path": "src/game objects/graphics/Many Line Stars.js",
               "name": "Many Line Stars.js",
               "size": 1819,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\multiple cameras.js",
+              "path": "src/game objects/graphics/multiple cameras.js",
               "name": "multiple cameras.js",
               "size": 2573,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\multiple graphic objects.js",
+              "path": "src/game objects/graphics/multiple graphic objects.js",
               "name": "multiple graphic objects.js",
               "size": 2132,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\multiple stroke rects.js",
+              "path": "src/game objects/graphics/multiple stroke rects.js",
               "name": "multiple stroke rects.js",
               "size": 1779,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\obj scene.js",
+              "path": "src/game objects/graphics/obj scene.js",
               "name": "obj scene.js",
               "size": 7643,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\obj viewer.js",
+              "path": "src/game objects/graphics/obj viewer.js",
               "name": "obj viewer.js",
               "size": 6451,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\obj world cam.js",
+              "path": "src/game objects/graphics/obj world cam.js",
               "name": "obj world cam.js",
               "size": 37637,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\obj world.js",
+              "path": "src/game objects/graphics/obj world.js",
               "name": "obj world.js",
               "size": 37528,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\pacman arc chomp chomp.js",
+              "path": "src/game objects/graphics/pacman arc chomp chomp.js",
               "name": "pacman arc chomp chomp.js",
               "size": 1006,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\pacman arc.js",
+              "path": "src/game objects/graphics/pacman arc.js",
               "name": "pacman arc.js",
               "size": 428,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\phaser logo 3d.js",
+              "path": "src/game objects/graphics/phaser logo 3d.js",
               "name": "phaser logo 3d.js",
               "size": 3970,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\phaser logo shift.js",
+              "path": "src/game objects/graphics/phaser logo shift.js",
               "name": "phaser logo shift.js",
               "size": 3761,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\phaser logo.js",
+              "path": "src/game objects/graphics/phaser logo.js",
               "name": "phaser logo.js",
               "size": 2754,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\primitive types.js",
+              "path": "src/game objects/graphics/primitive types.js",
               "name": "primitive types.js",
               "size": 565,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\primitives",
+              "path": "src/game objects/graphics/primitives",
               "name": "primitives",
               "children": [
                 {
-                  "path": "src\\game objects\\graphics\\primitives\\arc filled.js",
+                  "path": "src/game objects/graphics/primitives/arc filled.js",
                   "name": "arc filled.js",
                   "size": 846,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\primitives\\arc gradient filled.js",
+                  "path": "src/game objects/graphics/primitives/arc gradient filled.js",
                   "name": "arc gradient filled.js",
                   "size": 506,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\primitives\\arc stroked.js",
+                  "path": "src/game objects/graphics/primitives/arc stroked.js",
                   "name": "arc stroked.js",
                   "size": 890,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\primitives\\fill circle.js",
+                  "path": "src/game objects/graphics/primitives/fill circle.js",
                   "name": "fill circle.js",
                   "size": 563,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\primitives\\line between.js",
+                  "path": "src/game objects/graphics/primitives/line between.js",
                   "name": "line between.js",
                   "size": 357,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\primitives\\line filled.js",
+                  "path": "src/game objects/graphics/primitives/line filled.js",
                   "name": "line filled.js",
                   "size": 517,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\primitives\\line gradient stroked.js",
+                  "path": "src/game objects/graphics/primitives/line gradient stroked.js",
                   "name": "line gradient stroked.js",
                   "size": 396,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\primitives\\path filled.js",
+                  "path": "src/game objects/graphics/primitives/path filled.js",
                   "name": "path filled.js",
                   "size": 740,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\primitives\\path gradient filled.js",
+                  "path": "src/game objects/graphics/primitives/path gradient filled.js",
                   "name": "path gradient filled.js",
                   "size": 619,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\primitives\\path stroked.js",
+                  "path": "src/game objects/graphics/primitives/path stroked.js",
                   "name": "path stroked.js",
                   "size": 711,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\primitives\\rectangle filled texture.js",
+                  "path": "src/game objects/graphics/primitives/rectangle filled texture.js",
                   "name": "rectangle filled texture.js",
                   "size": 788,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\primitives\\rectangle filled.js",
+                  "path": "src/game objects/graphics/primitives/rectangle filled.js",
                   "name": "rectangle filled.js",
                   "size": 434,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\primitives\\rectangle gradient filled.js",
+                  "path": "src/game objects/graphics/primitives/rectangle gradient filled.js",
                   "name": "rectangle gradient filled.js",
                   "size": 594,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\primitives\\rectangle stroked.js",
+                  "path": "src/game objects/graphics/primitives/rectangle stroked.js",
                   "name": "rectangle stroked.js",
                   "size": 662,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\primitives\\scene stack test.js",
+                  "path": "src/game objects/graphics/primitives/scene stack test.js",
                   "name": "scene stack test.js",
                   "size": 1951,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\primitives\\split path filled.js",
+                  "path": "src/game objects/graphics/primitives/split path filled.js",
                   "name": "split path filled.js",
                   "size": 621,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\primitives\\triangle fill types.js",
+                  "path": "src/game objects/graphics/primitives/triangle fill types.js",
                   "name": "triangle fill types.js",
                   "size": 1114,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\primitives\\triangle filled texture.js",
+                  "path": "src/game objects/graphics/primitives/triangle filled texture.js",
                   "name": "triangle filled texture.js",
                   "size": 818,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\primitives\\triangle filled.js",
+                  "path": "src/game objects/graphics/primitives/triangle filled.js",
                   "name": "triangle filled.js",
                   "size": 675,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\primitives\\triangle gradient filled.js",
+                  "path": "src/game objects/graphics/primitives/triangle gradient filled.js",
                   "name": "triangle gradient filled.js",
                   "size": 533,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\primitives\\triangle gradient stroked.js",
+                  "path": "src/game objects/graphics/primitives/triangle gradient stroked.js",
                   "name": "triangle gradient stroked.js",
                   "size": 543,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\primitives\\triangle stroked.js",
+                  "path": "src/game objects/graphics/primitives/triangle stroked.js",
                   "name": "triangle stroked.js",
                   "size": 467,
                   "extension": ".js"
@@ -4087,155 +4087,155 @@
               "size": 15345
             },
             {
-              "path": "src\\game objects\\graphics\\rect test.js",
+              "path": "src/game objects/graphics/rect test.js",
               "name": "rect test.js",
               "size": 531,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\single obj viewer.js",
+              "path": "src/game objects/graphics/single obj viewer.js",
               "name": "single obj viewer.js",
               "size": 6947,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\spinning cube.js",
+              "path": "src/game objects/graphics/spinning cube.js",
               "name": "spinning cube.js",
               "size": 3142,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\star shape.js",
+              "path": "src/game objects/graphics/star shape.js",
               "name": "star shape.js",
               "size": 1301,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\stroke circle.js",
+              "path": "src/game objects/graphics/stroke circle.js",
               "name": "stroke circle.js",
               "size": 522,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\stroke path.js",
+              "path": "src/game objects/graphics/stroke path.js",
               "name": "stroke path.js",
               "size": 618,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\stroke rect.js",
+              "path": "src/game objects/graphics/stroke rect.js",
               "name": "stroke rect.js",
               "size": 449,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\stroke rounded rectangle.js",
+              "path": "src/game objects/graphics/stroke rounded rectangle.js",
               "name": "stroke rounded rectangle.js",
               "size": 610,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\stroke triangle.js",
+              "path": "src/game objects/graphics/stroke triangle.js",
               "name": "stroke triangle.js",
               "size": 605,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\teapot.js",
+              "path": "src/game objects/graphics/teapot.js",
               "name": "teapot.js",
               "size": 4814,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\trace.js",
+              "path": "src/game objects/graphics/trace.js",
               "name": "trace.js",
               "size": 1213,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\Trail.js",
+              "path": "src/game objects/graphics/Trail.js",
               "name": "Trail.js",
               "size": 2476,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\transform.js",
+              "path": "src/game objects/graphics/transform.js",
               "name": "transform.js",
               "size": 1242,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\graphics\\_mesh",
+              "path": "src/game objects/graphics/_mesh",
               "name": "_mesh",
               "children": [
                 {
-                  "path": "src\\game objects\\graphics\\_mesh\\draw mesh.js",
+                  "path": "src/game objects/graphics/_mesh/draw mesh.js",
                   "name": "draw mesh.js",
                   "size": 713,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\_mesh\\filled torus.js",
+                  "path": "src/game objects/graphics/_mesh/filled torus.js",
                   "name": "filled torus.js",
                   "size": 712,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\_mesh\\mesh battleship.js",
+                  "path": "src/game objects/graphics/_mesh/mesh battleship.js",
                   "name": "mesh battleship.js",
                   "size": 760,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\_mesh\\mesh deer.js",
+                  "path": "src/game objects/graphics/_mesh/mesh deer.js",
                   "name": "mesh deer.js",
                   "size": 676,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\_mesh\\mesh elephant.js",
+                  "path": "src/game objects/graphics/_mesh/mesh elephant.js",
                   "name": "mesh elephant.js",
                   "size": 927,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\_mesh\\mesh gun.js",
+                  "path": "src/game objects/graphics/_mesh/mesh gun.js",
                   "name": "mesh gun.js",
                   "size": 826,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\_mesh\\mesh scale.js",
+                  "path": "src/game objects/graphics/_mesh/mesh scale.js",
                   "name": "mesh scale.js",
                   "size": 679,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\_mesh\\mesh scene.js",
+                  "path": "src/game objects/graphics/_mesh/mesh scene.js",
                   "name": "mesh scene.js",
                   "size": 1097,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\_mesh\\mesh snowman.js",
+                  "path": "src/game objects/graphics/_mesh/mesh snowman.js",
                   "name": "mesh snowman.js",
                   "size": 774,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\_mesh\\mesh squirrel.js",
+                  "path": "src/game objects/graphics/_mesh/mesh squirrel.js",
                   "name": "mesh squirrel.js",
                   "size": 710,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\_mesh\\mesh test.js",
+                  "path": "src/game objects/graphics/_mesh/mesh test.js",
                   "name": "mesh test.js",
                   "size": 622,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\graphics\\_mesh\\mesh tree.js",
+                  "path": "src/game objects/graphics/_mesh/mesh tree.js",
                   "name": "mesh tree.js",
                   "size": 818,
                   "extension": ".js"
@@ -4247,95 +4247,95 @@
           "size": 191593
         },
         {
-          "path": "src\\game objects\\group",
+          "path": "src/game objects/group",
           "name": "group",
           "children": [
             {
-              "path": "src\\game objects\\group\\create child.js",
+              "path": "src/game objects/group/create child.js",
               "name": "create child.js",
               "size": 713,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\group\\create invaders.js",
+              "path": "src/game objects/group/create invaders.js",
               "name": "create invaders.js",
               "size": 1592,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\group\\create multiple keys.js",
+              "path": "src/game objects/group/create multiple keys.js",
               "name": "create multiple keys.js",
               "size": 1723,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\group\\create multiple.js",
+              "path": "src/game objects/group/create multiple.js",
               "name": "create multiple.js",
               "size": 1348,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\group\\destroy child.js",
+              "path": "src/game objects/group/destroy child.js",
               "name": "destroy child.js",
               "size": 1732,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\group\\multiple adds.js",
+              "path": "src/game objects/group/multiple adds.js",
               "name": "multiple adds.js",
               "size": 1070,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\group\\random frame.js",
+              "path": "src/game objects/group/random frame.js",
               "name": "random frame.js",
               "size": 949,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\group\\set rotation.js",
+              "path": "src/game objects/group/set rotation.js",
               "name": "set rotation.js",
               "size": 568,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\group\\set scale.js",
+              "path": "src/game objects/group/set scale.js",
               "name": "set scale.js",
               "size": 592,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\group\\set x.js",
+              "path": "src/game objects/group/set x.js",
               "name": "set x.js",
               "size": 808,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\group\\set xy.js",
+              "path": "src/game objects/group/set xy.js",
               "name": "set xy.js",
               "size": 829,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\group\\set y.js",
+              "path": "src/game objects/group/set y.js",
               "name": "set y.js",
               "size": 804,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\group\\shuffle.js",
+              "path": "src/game objects/group/shuffle.js",
               "name": "shuffle.js",
               "size": 1245,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\group\\sprite pool.js",
+              "path": "src/game objects/group/sprite pool.js",
               "name": "sprite pool.js",
               "size": 2564,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\group\\swirl.js",
+              "path": "src/game objects/group/swirl.js",
               "name": "swirl.js",
               "size": 619,
               "extension": ".js"
@@ -4344,101 +4344,101 @@
           "size": 17156
         },
         {
-          "path": "src\\game objects\\images",
+          "path": "src/game objects/images",
           "name": "images",
           "children": [
             {
-              "path": "src\\game objects\\images\\blend test.js",
+              "path": "src/game objects/images/blend test.js",
               "name": "blend test.js",
               "size": 849,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\images\\custom game object.js",
+              "path": "src/game objects/images/custom game object.js",
               "name": "custom game object.js",
               "size": 1071,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\images\\custom image class ES6.js",
+              "path": "src/game objects/images/custom image class ES6.js",
               "name": "custom image class ES6.js",
               "size": 704,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\images\\custom image class.js",
+              "path": "src/game objects/images/custom image class.js",
               "name": "custom image class.js",
               "size": 783,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\images\\destroy an image.js",
+              "path": "src/game objects/images/destroy an image.js",
               "name": "destroy an image.js",
               "size": 707,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\images\\flip.js",
+              "path": "src/game objects/images/flip.js",
               "name": "flip.js",
               "size": 919,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\images\\get bounds.js",
+              "path": "src/game objects/images/get bounds.js",
               "name": "get bounds.js",
               "size": 1407,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\images\\image alpha.js",
+              "path": "src/game objects/images/image alpha.js",
               "name": "image alpha.js",
               "size": 416,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\images\\image bounds.js",
+              "path": "src/game objects/images/image bounds.js",
               "name": "image bounds.js",
               "size": 1678,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\images\\image edge points.js",
+              "path": "src/game objects/images/image edge points.js",
               "name": "image edge points.js",
               "size": 1961,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\images\\image offset.js",
+              "path": "src/game objects/images/image offset.js",
               "name": "image offset.js",
               "size": 636,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\images\\image rotation.js",
+              "path": "src/game objects/images/image rotation.js",
               "name": "image rotation.js",
               "size": 486,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\images\\make image from config.js",
+              "path": "src/game objects/images/make image from config.js",
               "name": "make image from config.js",
               "size": 2000,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\images\\multiple alpha.js",
+              "path": "src/game objects/images/multiple alpha.js",
               "name": "multiple alpha.js",
               "size": 636,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\images\\multiple image rotation.js",
+              "path": "src/game objects/images/multiple image rotation.js",
               "name": "multiple image rotation.js",
               "size": 602,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\images\\single image.js",
+              "path": "src/game objects/images/single image.js",
               "name": "single image.js",
               "size": 520,
               "extension": ".js"
@@ -4447,65 +4447,65 @@
           "size": 15375
         },
         {
-          "path": "src\\game objects\\lights",
+          "path": "src/game objects/lights",
           "name": "lights",
           "children": [
             {
-              "path": "src\\game objects\\lights\\blitter light.js",
+              "path": "src/game objects/lights/blitter light.js",
               "name": "blitter light.js",
               "size": 2341,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\lights\\change max lights.js",
+              "path": "src/game objects/lights/change max lights.js",
               "name": "change max lights.js",
               "size": 1358,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\lights\\change scene.js",
+              "path": "src/game objects/lights/change scene.js",
               "name": "change scene.js",
               "size": 2028,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\lights\\dynamic tilemap layer.js",
+              "path": "src/game objects/lights/dynamic tilemap layer.js",
               "name": "dynamic tilemap layer.js",
               "size": 3340,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\lights\\graveyard.js",
+              "path": "src/game objects/lights/graveyard.js",
               "name": "graveyard.js",
               "size": 2775,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\lights\\light follow pointer.js",
+              "path": "src/game objects/lights/light follow pointer.js",
               "name": "light follow pointer.js",
               "size": 2261,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\lights\\mesh light.js",
+              "path": "src/game objects/lights/mesh light.js",
               "name": "mesh light.js",
               "size": 2808,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\lights\\rotated sprite.js",
+              "path": "src/game objects/lights/rotated sprite.js",
               "name": "rotated sprite.js",
               "size": 1098,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\lights\\spotlight.js",
+              "path": "src/game objects/lights/spotlight.js",
               "name": "spotlight.js",
               "size": 1038,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\lights\\tilesprite light.js",
+              "path": "src/game objects/lights/tilesprite light.js",
               "name": "tilesprite light.js",
               "size": 1867,
               "extension": ".js"
@@ -4514,53 +4514,53 @@
           "size": 20914
         },
         {
-          "path": "src\\game objects\\mesh",
+          "path": "src/game objects/mesh",
           "name": "mesh",
           "children": [
             {
-              "path": "src\\game objects\\mesh\\basic quad.js",
+              "path": "src/game objects/mesh/basic quad.js",
               "name": "basic quad.js",
               "size": 1485,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\mesh\\basic tri.js",
+              "path": "src/game objects/mesh/basic tri.js",
               "name": "basic tri.js",
               "size": 1330,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\mesh\\random quad tween.js",
+              "path": "src/game objects/mesh/random quad tween.js",
               "name": "random quad tween.js",
               "size": 2461,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\mesh\\random quad.js",
+              "path": "src/game objects/mesh/random quad.js",
               "name": "random quad.js",
               "size": 1844,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\mesh\\Simple Mesh.js",
+              "path": "src/game objects/mesh/Simple Mesh.js",
               "name": "Simple Mesh.js",
               "size": 3342,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\mesh\\UV Scroll.js",
+              "path": "src/game objects/mesh/UV Scroll.js",
               "name": "UV Scroll.js",
               "size": 1501,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\mesh\\Vertex Color.js",
+              "path": "src/game objects/mesh/Vertex Color.js",
               "name": "Vertex Color.js",
               "size": 1604,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\mesh\\vertice drag.js",
+              "path": "src/game objects/mesh/vertice drag.js",
               "name": "vertice drag.js",
               "size": 1818,
               "extension": ".js"
@@ -4569,389 +4569,389 @@
           "size": 15385
         },
         {
-          "path": "src\\game objects\\particle emitter",
+          "path": "src/game objects/particle emitter",
           "name": "particle emitter",
           "children": [
             {
-              "path": "src\\game objects\\particle emitter\\acceleration.js",
+              "path": "src/game objects/particle emitter/acceleration.js",
               "name": "acceleration.js",
               "size": 738,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\angled emitter.js",
+              "path": "src/game objects/particle emitter/angled emitter.js",
               "name": "angled emitter.js",
               "size": 754,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\camera test.js",
+              "path": "src/game objects/particle emitter/camera test.js",
               "name": "camera test.js",
               "size": 3539,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\change emitter order.js",
+              "path": "src/game objects/particle emitter/change emitter order.js",
               "name": "change emitter order.js",
               "size": 1312,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\christmas tree.js",
+              "path": "src/game objects/particle emitter/christmas tree.js",
               "name": "christmas tree.js",
               "size": 2294,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\collide emitter bounds sides.js",
+              "path": "src/game objects/particle emitter/collide emitter bounds sides.js",
               "name": "collide emitter bounds sides.js",
               "size": 906,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\create emitter from config 2.js",
+              "path": "src/game objects/particle emitter/create emitter from config 2.js",
               "name": "create emitter from config 2.js",
               "size": 665,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\create emitter from config 3.js",
+              "path": "src/game objects/particle emitter/create emitter from config 3.js",
               "name": "create emitter from config 3.js",
               "size": 707,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\create emitter from config 4.js",
+              "path": "src/game objects/particle emitter/create emitter from config 4.js",
               "name": "create emitter from config 4.js",
               "size": 1325,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\create emitter from config 5.js",
+              "path": "src/game objects/particle emitter/create emitter from config 5.js",
               "name": "create emitter from config 5.js",
               "size": 1058,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\create emitter from config.js",
+              "path": "src/game objects/particle emitter/create emitter from config.js",
               "name": "create emitter from config.js",
               "size": 1480,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\create emitter from JSON.js",
+              "path": "src/game objects/particle emitter/create emitter from JSON.js",
               "name": "create emitter from JSON.js",
               "size": 616,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\create emitter.js",
+              "path": "src/game objects/particle emitter/create emitter.js",
               "name": "create emitter.js",
               "size": 774,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\custom particles.js",
+              "path": "src/game objects/particle emitter/custom particles.js",
               "name": "custom particles.js",
               "size": 1633,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\death zone custom.js",
+              "path": "src/game objects/particle emitter/death zone custom.js",
               "name": "death zone custom.js",
               "size": 1440,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\death zone follow mouse.js",
+              "path": "src/game objects/particle emitter/death zone follow mouse.js",
               "name": "death zone follow mouse.js",
               "size": 1410,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\death zone from arcade body.js",
+              "path": "src/game objects/particle emitter/death zone from arcade body.js",
               "name": "death zone from arcade body.js",
               "size": 1187,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\death zone on enter.js",
+              "path": "src/game objects/particle emitter/death zone on enter.js",
               "name": "death zone on enter.js",
               "size": 1009,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\death zone on leave.js",
+              "path": "src/game objects/particle emitter/death zone on leave.js",
               "name": "death zone on leave.js",
               "size": 983,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\digital rain.js",
+              "path": "src/game objects/particle emitter/digital rain.js",
               "name": "digital rain.js",
               "size": 1710,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\double acceleration.js",
+              "path": "src/game objects/particle emitter/double acceleration.js",
               "name": "double acceleration.js",
               "size": 1026,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\dynamic emitter config property.js",
+              "path": "src/game objects/particle emitter/dynamic emitter config property.js",
               "name": "dynamic emitter config property.js",
               "size": 859,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\edge zone custom.js",
+              "path": "src/game objects/particle emitter/edge zone custom.js",
               "name": "edge zone custom.js",
               "size": 1415,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\edge zone from curve.js",
+              "path": "src/game objects/particle emitter/edge zone from curve.js",
               "name": "edge zone from curve.js",
               "size": 1476,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\edge zone speed.js",
+              "path": "src/game objects/particle emitter/edge zone speed.js",
               "name": "edge zone speed.js",
               "size": 1142,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\edge zone.js",
+              "path": "src/game objects/particle emitter/edge zone.js",
               "name": "edge zone.js",
               "size": 1416,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\electric 2.js",
+              "path": "src/game objects/particle emitter/electric 2.js",
               "name": "electric 2.js",
               "size": 3854,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\electric.js",
+              "path": "src/game objects/particle emitter/electric.js",
               "name": "electric.js",
               "size": 3863,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\emit from manager.js",
+              "path": "src/game objects/particle emitter/emit from manager.js",
               "name": "emit from manager.js",
               "size": 1907,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\emit from shape.js",
+              "path": "src/game objects/particle emitter/emit from shape.js",
               "name": "emit from shape.js",
               "size": 1743,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\emit from sprites.js",
+              "path": "src/game objects/particle emitter/emit from sprites.js",
               "name": "emit from sprites.js",
               "size": 1907,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\emit from texture.js",
+              "path": "src/game objects/particle emitter/emit from texture.js",
               "name": "emit from texture.js",
               "size": 1484,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\emitter bounds.js",
+              "path": "src/game objects/particle emitter/emitter bounds.js",
               "name": "emitter bounds.js",
               "size": 1028,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\emitter follow sprite.js",
+              "path": "src/game objects/particle emitter/emitter follow sprite.js",
               "name": "emitter follow sprite.js",
               "size": 1371,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\explode test.js",
+              "path": "src/game objects/particle emitter/explode test.js",
               "name": "explode test.js",
               "size": 1382,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\fire max 10 particles.js",
+              "path": "src/game objects/particle emitter/fire max 10 particles.js",
               "name": "fire max 10 particles.js",
               "size": 1340,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\fireballs.js",
+              "path": "src/game objects/particle emitter/fireballs.js",
               "name": "fireballs.js",
               "size": 804,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\fireworks.js",
+              "path": "src/game objects/particle emitter/fireworks.js",
               "name": "fireworks.js",
               "size": 1822,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\follow sprite.js",
+              "path": "src/game objects/particle emitter/follow sprite.js",
               "name": "follow sprite.js",
               "size": 995,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\frame cycle.js",
+              "path": "src/game objects/particle emitter/frame cycle.js",
               "name": "frame cycle.js",
               "size": 995,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\gravity well.js",
+              "path": "src/game objects/particle emitter/gravity well.js",
               "name": "gravity well.js",
               "size": 848,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\manager transform.js",
+              "path": "src/game objects/particle emitter/manager transform.js",
               "name": "manager transform.js",
               "size": 1230,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\mouse trail.js",
+              "path": "src/game objects/particle emitter/mouse trail.js",
               "name": "mouse trail.js",
               "size": 3156,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\move to center.js",
+              "path": "src/game objects/particle emitter/move to center.js",
               "name": "move to center.js",
               "size": 964,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\move to.js",
+              "path": "src/game objects/particle emitter/move to.js",
               "name": "move to.js",
               "size": 922,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\multi frame test.js",
+              "path": "src/game objects/particle emitter/multi frame test.js",
               "name": "multi frame test.js",
               "size": 2258,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\multiple emitters.js",
+              "path": "src/game objects/particle emitter/multiple emitters.js",
               "name": "multiple emitters.js",
               "size": 1076,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\parallax.js",
+              "path": "src/game objects/particle emitter/parallax.js",
               "name": "parallax.js",
               "size": 1457,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\particle editor.js",
+              "path": "src/game objects/particle emitter/particle editor.js",
               "name": "particle editor.js",
               "size": 4619,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\particle processor.js",
+              "path": "src/game objects/particle emitter/particle processor.js",
               "name": "particle processor.js",
               "size": 1659,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\particles on a moving curve.js",
+              "path": "src/game objects/particle emitter/particles on a moving curve.js",
               "name": "particles on a moving curve.js",
               "size": 1847,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\particles on a path.js",
+              "path": "src/game objects/particle emitter/particles on a path.js",
               "name": "particles on a path.js",
               "size": 818,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\random emit zone custom.js",
+              "path": "src/game objects/particle emitter/random emit zone custom.js",
               "name": "random emit zone custom.js",
               "size": 1196,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\random emit zone.js",
+              "path": "src/game objects/particle emitter/random emit zone.js",
               "name": "random emit zone.js",
               "size": 1145,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\rotating line.js",
+              "path": "src/game objects/particle emitter/rotating line.js",
               "name": "rotating line.js",
               "size": 973,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\scale emitter.js",
+              "path": "src/game objects/particle emitter/scale emitter.js",
               "name": "scale emitter.js",
               "size": 869,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\stepped angle.js",
+              "path": "src/game objects/particle emitter/stepped angle.js",
               "name": "stepped angle.js",
               "size": 1655,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\stepped lifespan.js",
+              "path": "src/game objects/particle emitter/stepped lifespan.js",
               "name": "stepped lifespan.js",
               "size": 692,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\stepped position and speed.js",
+              "path": "src/game objects/particle emitter/stepped position and speed.js",
               "name": "stepped position and speed.js",
               "size": 856,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\stepped position.js",
+              "path": "src/game objects/particle emitter/stepped position.js",
               "name": "stepped position.js",
               "size": 792,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\stepped speed.js",
+              "path": "src/game objects/particle emitter/stepped speed.js",
               "name": "stepped speed.js",
               "size": 742,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\test new ops.js",
+              "path": "src/game objects/particle emitter/test new ops.js",
               "name": "test new ops.js",
               "size": 1799,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\tint.js",
+              "path": "src/game objects/particle emitter/tint.js",
               "name": "tint.js",
               "size": 711,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\particle emitter\\y position range.js",
+              "path": "src/game objects/particle emitter/y position range.js",
               "name": "y position range.js",
               "size": 727,
               "extension": ".js"
@@ -4960,17 +4960,17 @@
           "size": 90380
         },
         {
-          "path": "src\\game objects\\quad",
+          "path": "src/game objects/quad",
           "name": "quad",
           "children": [
             {
-              "path": "src\\game objects\\quad\\basic quad.js",
+              "path": "src/game objects/quad/basic quad.js",
               "name": "basic quad.js",
               "size": 3173,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\quad\\quad with atlas frame.js",
+              "path": "src/game objects/quad/quad with atlas frame.js",
               "name": "quad with atlas frame.js",
               "size": 3719,
               "extension": ".js"
@@ -4979,251 +4979,251 @@
           "size": 6892
         },
         {
-          "path": "src\\game objects\\render texture",
+          "path": "src/game objects/render texture",
           "name": "render texture",
           "children": [
             {
-              "path": "src\\game objects\\render texture\\atlas frame to render texture.js",
+              "path": "src/game objects/render texture/atlas frame to render texture.js",
               "name": "atlas frame to render texture.js",
               "size": 771,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\blitter to render texture.js",
+              "path": "src/game objects/render texture/blitter to render texture.js",
               "name": "blitter to render texture.js",
               "size": 650,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\brute force.js",
+              "path": "src/game objects/render texture/brute force.js",
               "name": "brute force.js",
               "size": 1101,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\change frame.js",
+              "path": "src/game objects/render texture/change frame.js",
               "name": "change frame.js",
               "size": 1213,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\container to render texture.js",
+              "path": "src/game objects/render texture/container to render texture.js",
               "name": "container to render texture.js",
               "size": 1074,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\destroy render texture.js",
+              "path": "src/game objects/render texture/destroy render texture.js",
               "name": "destroy render texture.js",
               "size": 1184,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\draw on texture.js",
+              "path": "src/game objects/render texture/draw on texture.js",
               "name": "draw on texture.js",
               "size": 2081,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\draw to render texture.js",
+              "path": "src/game objects/render texture/draw to render texture.js",
               "name": "draw to render texture.js",
               "size": 3316,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\dynamic bitmap text to render texture.js",
+              "path": "src/game objects/render texture/dynamic bitmap text to render texture.js",
               "name": "dynamic bitmap text to render texture.js",
               "size": 1060,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\dynamic tilemap to render texture.js",
+              "path": "src/game objects/render texture/dynamic tilemap to render texture.js",
               "name": "dynamic tilemap to render texture.js",
               "size": 821,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\erase part of render texture canvas.js",
+              "path": "src/game objects/render texture/erase part of render texture canvas.js",
               "name": "erase part of render texture canvas.js",
               "size": 1154,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\erase part of render texture.js",
+              "path": "src/game objects/render texture/erase part of render texture.js",
               "name": "erase part of render texture.js",
               "size": 1180,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\explosion.js",
+              "path": "src/game objects/render texture/explosion.js",
               "name": "explosion.js",
               "size": 1471,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\fireball.js",
+              "path": "src/game objects/render texture/fireball.js",
               "name": "fireball.js",
               "size": 1455,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\graphics to render texture.js",
+              "path": "src/game objects/render texture/graphics to render texture.js",
               "name": "graphics to render texture.js",
               "size": 1325,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\group to render texture.js",
+              "path": "src/game objects/render texture/group to render texture.js",
               "name": "group to render texture.js",
               "size": 1864,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\paint interpolated shadow.js",
+              "path": "src/game objects/render texture/paint interpolated shadow.js",
               "name": "paint interpolated shadow.js",
               "size": 1485,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\paint interpolated.js",
+              "path": "src/game objects/render texture/paint interpolated.js",
               "name": "paint interpolated.js",
               "size": 1181,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\paint tinted.js",
+              "path": "src/game objects/render texture/paint tinted.js",
               "name": "paint tinted.js",
               "size": 822,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\paint.js",
+              "path": "src/game objects/render texture/paint.js",
               "name": "paint.js",
               "size": 582,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\particle emitter to render texture.js",
+              "path": "src/game objects/render texture/particle emitter to render texture.js",
               "name": "particle emitter to render texture.js",
               "size": 969,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\pixel art test.js",
+              "path": "src/game objects/render texture/pixel art test.js",
               "name": "pixel art test.js",
               "size": 543,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\render texture larger than camera.js",
+              "path": "src/game objects/render texture/render texture larger than camera.js",
               "name": "render texture larger than camera.js",
               "size": 1225,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\render texture to render texture.js",
+              "path": "src/game objects/render texture/render texture to render texture.js",
               "name": "render texture to render texture.js",
               "size": 974,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\resize render texture.js",
+              "path": "src/game objects/render texture/resize render texture.js",
               "name": "resize render texture.js",
               "size": 998,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\resize rendertexture.js",
+              "path": "src/game objects/render texture/resize rendertexture.js",
               "name": "resize rendertexture.js",
               "size": 1038,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\save texture.js",
+              "path": "src/game objects/render texture/save texture.js",
               "name": "save texture.js",
               "size": 777,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\scene to render texture quad.js",
+              "path": "src/game objects/render texture/scene to render texture quad.js",
               "name": "scene to render texture quad.js",
               "size": 6996,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\scene to render texture with crop.js",
+              "path": "src/game objects/render texture/scene to render texture with crop.js",
               "name": "scene to render texture with crop.js",
               "size": 5390,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\scene to render texture.js",
+              "path": "src/game objects/render texture/scene to render texture.js",
               "name": "scene to render texture.js",
               "size": 4555,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\scratch.js",
+              "path": "src/game objects/render texture/scratch.js",
               "name": "scratch.js",
               "size": 1926,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\shape to render texture.js",
+              "path": "src/game objects/render texture/shape to render texture.js",
               "name": "shape to render texture.js",
               "size": 438,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\sparks.js",
+              "path": "src/game objects/render texture/sparks.js",
               "name": "sparks.js",
               "size": 1082,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\sprite to render texture.js",
+              "path": "src/game objects/render texture/sprite to render texture.js",
               "name": "sprite to render texture.js",
               "size": 652,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\static bitmap text to render texture.js",
+              "path": "src/game objects/render texture/static bitmap text to render texture.js",
               "name": "static bitmap text to render texture.js",
               "size": 734,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\static tilemap to render texture.js",
+              "path": "src/game objects/render texture/static tilemap to render texture.js",
               "name": "static tilemap to render texture.js",
               "size": 1717,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\text to render texture.js",
+              "path": "src/game objects/render texture/text to render texture.js",
               "name": "text to render texture.js",
               "size": 545,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\texture key to render texture.js",
+              "path": "src/game objects/render texture/texture key to render texture.js",
               "name": "texture key to render texture.js",
               "size": 550,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\trail.js",
+              "path": "src/game objects/render texture/trail.js",
               "name": "trail.js",
               "size": 1178,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\trail2.js",
+              "path": "src/game objects/render texture/trail2.js",
               "name": "trail2.js",
               "size": 656,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\render texture\\transform draw.js",
+              "path": "src/game objects/render texture/transform draw.js",
               "name": "transform draw.js",
               "size": 582,
               "extension": ".js"
@@ -5232,71 +5232,71 @@
           "size": 59315
         },
         {
-          "path": "src\\game objects\\shaders",
+          "path": "src/game objects/shaders",
           "name": "shaders",
           "children": [
             {
-              "path": "src\\game objects\\shaders\\buffer a.js",
+              "path": "src/game objects/shaders/buffer a.js",
               "name": "buffer a.js",
               "size": 16018,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shaders\\buffer b.js",
+              "path": "src/game objects/shaders/buffer b.js",
               "name": "buffer b.js",
               "size": 2352,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shaders\\change shader texture.js",
+              "path": "src/game objects/shaders/change shader texture.js",
               "name": "change shader texture.js",
               "size": 1298,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shaders\\load shader.js",
+              "path": "src/game objects/shaders/load shader.js",
               "name": "load shader.js",
               "size": 397,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shaders\\save shader as texture.js",
+              "path": "src/game objects/shaders/save shader as texture.js",
               "name": "save shader as texture.js",
               "size": 1139,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shaders\\shader arcade physics.js",
+              "path": "src/game objects/shaders/shader arcade physics.js",
               "name": "shader arcade physics.js",
               "size": 1023,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shaders\\shader as a mask.js",
+              "path": "src/game objects/shaders/shader as a mask.js",
               "name": "shader as a mask.js",
               "size": 833,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shaders\\shader bundle.js",
+              "path": "src/game objects/shaders/shader bundle.js",
               "name": "shader bundle.js",
               "size": 752,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shaders\\shader mass texture test.js",
+              "path": "src/game objects/shaders/shader mass texture test.js",
               "name": "shader mass texture test.js",
               "size": 1245,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shaders\\shader transforms.js",
+              "path": "src/game objects/shaders/shader transforms.js",
               "name": "shader transforms.js",
               "size": 1043,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shaders\\using a shader as a buffer.js",
+              "path": "src/game objects/shaders/using a shader as a buffer.js",
               "name": "using a shader as a buffer.js",
               "size": 943,
               "extension": ".js"
@@ -5305,143 +5305,143 @@
           "size": 27043
         },
         {
-          "path": "src\\game objects\\shapes",
+          "path": "src/game objects/shapes",
           "name": "shapes",
           "children": [
             {
-              "path": "src\\game objects\\shapes\\arc.js",
+              "path": "src/game objects/shapes/arc.js",
               "name": "arc.js",
               "size": 1397,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shapes\\blend modes.js",
+              "path": "src/game objects/shapes/blend modes.js",
               "name": "blend modes.js",
               "size": 519,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shapes\\circle.js",
+              "path": "src/game objects/shapes/circle.js",
               "name": "circle.js",
               "size": 1321,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shapes\\curve.js",
+              "path": "src/game objects/shapes/curve.js",
               "name": "curve.js",
               "size": 846,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shapes\\draw.js",
+              "path": "src/game objects/shapes/draw.js",
               "name": "draw.js",
               "size": 5800,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shapes\\ellipse.js",
+              "path": "src/game objects/shapes/ellipse.js",
               "name": "ellipse.js",
               "size": 1341,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shapes\\grid.js",
+              "path": "src/game objects/shapes/grid.js",
               "name": "grid.js",
               "size": 1072,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shapes\\iso birdie.js",
+              "path": "src/game objects/shapes/iso birdie.js",
               "name": "iso birdie.js",
               "size": 1580,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shapes\\iso box.js",
+              "path": "src/game objects/shapes/iso box.js",
               "name": "iso box.js",
               "size": 821,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shapes\\iso draw.js",
+              "path": "src/game objects/shapes/iso draw.js",
               "name": "iso draw.js",
               "size": 5437,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shapes\\iso image.js",
+              "path": "src/game objects/shapes/iso image.js",
               "name": "iso image.js",
               "size": 2932,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shapes\\iso landscape.js",
+              "path": "src/game objects/shapes/iso landscape.js",
               "name": "iso landscape.js",
               "size": 3187,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shapes\\iso triangle.js",
+              "path": "src/game objects/shapes/iso triangle.js",
               "name": "iso triangle.js",
               "size": 857,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shapes\\line.js",
+              "path": "src/game objects/shapes/line.js",
               "name": "line.js",
               "size": 1354,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shapes\\polygon with matter physics.js",
+              "path": "src/game objects/shapes/polygon with matter physics.js",
               "name": "polygon with matter physics.js",
               "size": 1519,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shapes\\polygon.js",
+              "path": "src/game objects/shapes/polygon.js",
               "name": "polygon.js",
               "size": 1359,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shapes\\rectangle with arcade physics.js",
+              "path": "src/game objects/shapes/rectangle with arcade physics.js",
               "name": "rectangle with arcade physics.js",
               "size": 884,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shapes\\rectangle.js",
+              "path": "src/game objects/shapes/rectangle.js",
               "name": "rectangle.js",
               "size": 1325,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shapes\\spline.js",
+              "path": "src/game objects/shapes/spline.js",
               "name": "spline.js",
               "size": 883,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shapes\\stacker es6.js",
+              "path": "src/game objects/shapes/stacker es6.js",
               "name": "stacker es6.js",
               "size": 16815,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shapes\\stacker.js",
+              "path": "src/game objects/shapes/stacker.js",
               "name": "stacker.js",
               "size": 8738,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shapes\\star.js",
+              "path": "src/game objects/shapes/star.js",
               "name": "star.js",
               "size": 1301,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\shapes\\triangle.js",
+              "path": "src/game objects/shapes/triangle.js",
               "name": "triangle.js",
               "size": 1409,
               "extension": ".js"
@@ -5450,59 +5450,59 @@
           "size": 62697
         },
         {
-          "path": "src\\game objects\\sprites",
+          "path": "src/game objects/sprites",
           "name": "sprites",
           "children": [
             {
-              "path": "src\\game objects\\sprites\\create from config.js",
+              "path": "src/game objects/sprites/create from config.js",
               "name": "create from config.js",
               "size": 2001,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\sprites\\custom sprite class ES6.js",
+              "path": "src/game objects/sprites/custom sprite class ES6.js",
               "name": "custom sprite class ES6.js",
               "size": 775,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\sprites\\moving sprite.js",
+              "path": "src/game objects/sprites/moving sprite.js",
               "name": "moving sprite.js",
               "size": 539,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\sprites\\multiple sprites.js",
+              "path": "src/game objects/sprites/multiple sprites.js",
               "name": "multiple sprites.js",
               "size": 570,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\sprites\\rotate around a sprite.js",
+              "path": "src/game objects/sprites/rotate around a sprite.js",
               "name": "rotate around a sprite.js",
               "size": 1224,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\sprites\\single sprite.js",
+              "path": "src/game objects/sprites/single sprite.js",
               "name": "single sprite.js",
               "size": 370,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\sprites\\sprite alpha.js",
+              "path": "src/game objects/sprites/sprite alpha.js",
               "name": "sprite alpha.js",
               "size": 417,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\sprites\\sprite rotation.js",
+              "path": "src/game objects/sprites/sprite rotation.js",
               "name": "sprite rotation.js",
               "size": 2315,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\sprites\\to json.js",
+              "path": "src/game objects/sprites/to json.js",
               "name": "to json.js",
               "size": 614,
               "extension": ".js"
@@ -5511,41 +5511,41 @@
           "size": 8825
         },
         {
-          "path": "src\\game objects\\tests",
+          "path": "src/game objects/tests",
           "name": "tests",
           "children": [
             {
-              "path": "src\\game objects\\tests\\dynamic bitmap text.js",
+              "path": "src/game objects/tests/dynamic bitmap text.js",
               "name": "dynamic bitmap text.js",
               "size": 1816,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\tests\\image.js",
+              "path": "src/game objects/tests/image.js",
               "name": "image.js",
               "size": 1562,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\tests\\single tilesprite.js",
+              "path": "src/game objects/tests/single tilesprite.js",
               "name": "single tilesprite.js",
               "size": 489,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\tests\\static bitmap text.js",
+              "path": "src/game objects/tests/static bitmap text.js",
               "name": "static bitmap text.js",
               "size": 1767,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\tests\\text.js",
+              "path": "src/game objects/tests/text.js",
               "name": "text.js",
               "size": 1638,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\tests\\tilesprite.js",
+              "path": "src/game objects/tests/tilesprite.js",
               "name": "tilesprite.js",
               "size": 1646,
               "extension": ".js"
@@ -5554,121 +5554,121 @@
           "size": 8918
         },
         {
-          "path": "src\\game objects\\text",
+          "path": "src/game objects/text",
           "name": "text",
           "children": [
             {
-              "path": "src\\game objects\\text\\static",
+              "path": "src/game objects/text/static",
               "name": "static",
               "children": [
                 {
-                  "path": "src\\game objects\\text\\static\\align text.js",
+                  "path": "src/game objects/text/static/align text.js",
                   "name": "align text.js",
                   "size": 804,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\text\\static\\basic text.js",
+                  "path": "src/game objects/text/static/basic text.js",
                   "name": "basic text.js",
                   "size": 602,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\text\\static\\change text.js",
+                  "path": "src/game objects/text/static/change text.js",
                   "name": "change text.js",
                   "size": 618,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\text\\static\\create from config.js",
+                  "path": "src/game objects/text/static/create from config.js",
                   "name": "create from config.js",
                   "size": 804,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\text\\static\\custom webfont.js",
+                  "path": "src/game objects/text/static/custom webfont.js",
                   "name": "custom webfont.js",
                   "size": 1452,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\text\\static\\emojis.js",
+                  "path": "src/game objects/text/static/emojis.js",
                   "name": "emojis.js",
                   "size": 898,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\text\\static\\google webfont.js",
+                  "path": "src/game objects/text/static/google webfont.js",
                   "name": "google webfont.js",
                   "size": 1257,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\text\\static\\italic text.js",
+                  "path": "src/game objects/text/static/italic text.js",
                   "name": "italic text.js",
                   "size": 930,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\text\\static\\line spacing.js",
+                  "path": "src/game objects/text/static/line spacing.js",
                   "name": "line spacing.js",
                   "size": 1647,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\text\\static\\multi line text with alignment.js",
+                  "path": "src/game objects/text/static/multi line text with alignment.js",
                   "name": "multi line text with alignment.js",
                   "size": 1851,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\text\\static\\multi line text.js",
+                  "path": "src/game objects/text/static/multi line text.js",
                   "name": "multi line text.js",
                   "size": 1835,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\text\\static\\padding from config.js",
+                  "path": "src/game objects/text/static/padding from config.js",
                   "name": "padding from config.js",
                   "size": 1626,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\text\\static\\right origin.js",
+                  "path": "src/game objects/text/static/right origin.js",
                   "name": "right origin.js",
                   "size": 623,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\text\\static\\right to left text.js",
+                  "path": "src/game objects/text/static/right to left text.js",
                   "name": "right to left text.js",
                   "size": 1248,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\text\\static\\set test string.js",
+                  "path": "src/game objects/text/static/set test string.js",
                   "name": "set test string.js",
                   "size": 727,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\text\\static\\shadow stroke styles.js",
+                  "path": "src/game objects/text/static/shadow stroke styles.js",
                   "name": "shadow stroke styles.js",
                   "size": 1575,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\text\\static\\speech bubble.js",
+                  "path": "src/game objects/text/static/speech bubble.js",
                   "name": "speech bubble.js",
                   "size": 2807,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\text\\static\\tests",
+                  "path": "src/game objects/text/static/tests",
                   "name": "tests",
                   "children": [
                     {
-                      "path": "src\\game objects\\text\\static\\tests\\word wrap.js",
+                      "path": "src/game objects/text/static/tests/word wrap.js",
                       "name": "word wrap.js",
                       "size": 3464,
                       "extension": ".js"
@@ -5677,55 +5677,55 @@
                   "size": 3464
                 },
                 {
-                  "path": "src\\game objects\\text\\static\\text bounds.js",
+                  "path": "src/game objects/text/static/text bounds.js",
                   "name": "text bounds.js",
                   "size": 2977,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\text\\static\\text key.js",
+                  "path": "src/game objects/text/static/text key.js",
                   "name": "text key.js",
                   "size": 296,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\text\\static\\text metrics.js",
+                  "path": "src/game objects/text/static/text metrics.js",
                   "name": "text metrics.js",
                   "size": 968,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\text\\static\\text origin.js",
+                  "path": "src/game objects/text/static/text origin.js",
                   "name": "text origin.js",
                   "size": 855,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\text\\static\\text padding.js",
+                  "path": "src/game objects/text/static/text padding.js",
                   "name": "text padding.js",
                   "size": 1201,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\text\\static\\text with fallback font.js",
+                  "path": "src/game objects/text/static/text with fallback font.js",
                   "name": "text with fallback font.js",
                   "size": 361,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\text\\static\\to json.js",
+                  "path": "src/game objects/text/static/to json.js",
                   "name": "to json.js",
                   "size": 594,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\text\\static\\word wrap by callback.js",
+                  "path": "src/game objects/text/static/word wrap by callback.js",
                   "name": "word wrap by callback.js",
                   "size": 1104,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\text\\static\\word wrap by width.js",
+                  "path": "src/game objects/text/static/word wrap by width.js",
                   "name": "word wrap by width.js",
                   "size": 2027,
                   "extension": ".js"
@@ -5737,65 +5737,65 @@
           "size": 35151
         },
         {
-          "path": "src\\game objects\\tile sprite",
+          "path": "src/game objects/tile sprite",
           "name": "tile sprite",
           "children": [
             {
-              "path": "src\\game objects\\tile sprite\\Atlas - Canvas.js",
+              "path": "src/game objects/tile sprite/Atlas - Canvas.js",
               "name": "Atlas - Canvas.js",
               "size": 931,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\tile sprite\\Atlas.js",
+              "path": "src/game objects/tile sprite/Atlas.js",
               "name": "Atlas.js",
               "size": 930,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\tile sprite\\change frame.js",
+              "path": "src/game objects/tile sprite/change frame.js",
               "name": "change frame.js",
               "size": 1529,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\tile sprite\\create from frame.js",
+              "path": "src/game objects/tile sprite/create from frame.js",
               "name": "create from frame.js",
               "size": 1088,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\tile sprite\\Example - Canvas.js",
+              "path": "src/game objects/tile sprite/Example - Canvas.js",
               "name": "Example - Canvas.js",
               "size": 939,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\tile sprite\\Example 2 - Canvas.js",
+              "path": "src/game objects/tile sprite/Example 2 - Canvas.js",
               "name": "Example 2 - Canvas.js",
               "size": 1149,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\tile sprite\\Example 2.js",
+              "path": "src/game objects/tile sprite/Example 2.js",
               "name": "Example 2.js",
               "size": 1148,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\tile sprite\\Example.js",
+              "path": "src/game objects/tile sprite/Example.js",
               "name": "Example.js",
               "size": 1170,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\tile sprite\\flipped.js",
+              "path": "src/game objects/tile sprite/flipped.js",
               "name": "flipped.js",
               "size": 660,
               "extension": ".js"
             },
             {
-              "path": "src\\game objects\\tile sprite\\tilesprite pixel art test.js",
+              "path": "src/game objects/tile sprite/tilesprite pixel art test.js",
               "name": "tilesprite pixel art test.js",
               "size": 962,
               "extension": ".js"
@@ -5804,87 +5804,87 @@
           "size": 10506
         },
         {
-          "path": "src\\game objects\\tilemap",
+          "path": "src/game objects/tilemap",
           "name": "tilemap",
           "children": [
             {
-              "path": "src\\game objects\\tilemap\\collision",
+              "path": "src/game objects/tilemap/collision",
               "name": "collision",
               "children": [
                 {
-                  "path": "src\\game objects\\tilemap\\collision\\csv map arcade physics.js",
+                  "path": "src/game objects/tilemap/collision/csv map arcade physics.js",
                   "name": "csv map arcade physics.js",
                   "size": 4384,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\collision\\matter destroy tile bodies.js",
+                  "path": "src/game objects/tilemap/collision/matter destroy tile bodies.js",
                   "name": "matter destroy tile bodies.js",
                   "size": 13455,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\collision\\matter detect collision with tile.js",
+                  "path": "src/game objects/tilemap/collision/matter detect collision with tile.js",
                   "name": "matter detect collision with tile.js",
                   "size": 5233,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\collision\\matter ghost collisions.js",
+                  "path": "src/game objects/tilemap/collision/matter ghost collisions.js",
                   "name": "matter ghost collisions.js",
                   "size": 3962,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\collision\\matter platformer modify map.js",
+                  "path": "src/game objects/tilemap/collision/matter platformer modify map.js",
                   "name": "matter platformer modify map.js",
                   "size": 13288,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\collision\\matter platformer with wall jumping.js",
+                  "path": "src/game objects/tilemap/collision/matter platformer with wall jumping.js",
                   "name": "matter platformer with wall jumping.js",
                   "size": 11518,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\collision\\matter.js",
+                  "path": "src/game objects/tilemap/collision/matter.js",
                   "name": "matter.js",
                   "size": 2823,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\collision\\multiple tile sizes.js",
+                  "path": "src/game objects/tilemap/collision/multiple tile sizes.js",
                   "name": "multiple tile sizes.js",
                   "size": 4131,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\collision\\non-slope map and impact.js",
+                  "path": "src/game objects/tilemap/collision/non-slope map and impact.js",
                   "name": "non-slope map and impact.js",
                   "size": 3528,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\collision\\simple map.js",
+                  "path": "src/game objects/tilemap/collision/simple map.js",
                   "name": "simple map.js",
                   "size": 1898,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\collision\\tile callbacks.js",
+                  "path": "src/game objects/tilemap/collision/tile callbacks.js",
                   "name": "tile callbacks.js",
                   "size": 4423,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\collision\\tiled map and impact.js",
+                  "path": "src/game objects/tilemap/collision/tiled map and impact.js",
                   "name": "tiled map and impact.js",
                   "size": 3292,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\collision\\weltmeister map and impact.js",
+                  "path": "src/game objects/tilemap/collision/weltmeister map and impact.js",
                   "name": "weltmeister map and impact.js",
                   "size": 2361,
                   "extension": ".js"
@@ -5893,119 +5893,119 @@
               "size": 74296
             },
             {
-              "path": "src\\game objects\\tilemap\\dynamic",
+              "path": "src/game objects/tilemap/dynamic",
               "name": "dynamic",
               "children": [
                 {
-                  "path": "src\\game objects\\tilemap\\dynamic\\base tile size.js",
+                  "path": "src/game objects/tilemap/dynamic/base tile size.js",
                   "name": "base tile size.js",
                   "size": 1929,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\dynamic\\copy tiles.js",
+                  "path": "src/game objects/tilemap/dynamic/copy tiles.js",
                   "name": "copy tiles.js",
                   "size": 2825,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\dynamic\\creating blank layers.js",
+                  "path": "src/game objects/tilemap/dynamic/creating blank layers.js",
                   "name": "creating blank layers.js",
                   "size": 1803,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\dynamic\\dungeon generator.js",
+                  "path": "src/game objects/tilemap/dynamic/dungeon generator.js",
                   "name": "dungeon generator.js",
                   "size": 21499,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\dynamic\\dynamic to static.js",
+                  "path": "src/game objects/tilemap/dynamic/dynamic to static.js",
                   "name": "dynamic to static.js",
                   "size": 2110,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\dynamic\\endless map.js",
+                  "path": "src/game objects/tilemap/dynamic/endless map.js",
                   "name": "endless map.js",
                   "size": 2072,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\dynamic\\fill tiles.js",
+                  "path": "src/game objects/tilemap/dynamic/fill tiles.js",
                   "name": "fill tiles.js",
                   "size": 2217,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\dynamic\\get tiles in shape.js",
+                  "path": "src/game objects/tilemap/dynamic/get tiles in shape.js",
                   "name": "get tiles in shape.js",
                   "size": 5326,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\dynamic\\light map.js",
+                  "path": "src/game objects/tilemap/dynamic/light map.js",
                   "name": "light map.js",
                   "size": 3340,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\dynamic\\map vs layer with one layer.js",
+                  "path": "src/game objects/tilemap/dynamic/map vs layer with one layer.js",
                   "name": "map vs layer with one layer.js",
                   "size": 1200,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\dynamic\\paint-tiles.js",
+                  "path": "src/game objects/tilemap/dynamic/paint-tiles.js",
                   "name": "paint-tiles.js",
                   "size": 2896,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\dynamic\\platform maker.js",
+                  "path": "src/game objects/tilemap/dynamic/platform maker.js",
                   "name": "platform maker.js",
                   "size": 5411,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\dynamic\\put tiles.js",
+                  "path": "src/game objects/tilemap/dynamic/put tiles.js",
                   "name": "put tiles.js",
                   "size": 3351,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\dynamic\\randomize tiles.js",
+                  "path": "src/game objects/tilemap/dynamic/randomize tiles.js",
                   "name": "randomize tiles.js",
                   "size": 2357,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\dynamic\\replace tiles.js",
+                  "path": "src/game objects/tilemap/dynamic/replace tiles.js",
                   "name": "replace tiles.js",
                   "size": 1976,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\dynamic\\shuffle tiles.js",
+                  "path": "src/game objects/tilemap/dynamic/shuffle tiles.js",
                   "name": "shuffle tiles.js",
                   "size": 2176,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\dynamic\\swap tiles.js",
+                  "path": "src/game objects/tilemap/dynamic/swap tiles.js",
                   "name": "swap tiles.js",
                   "size": 2080,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\dynamic\\tile draw order.js",
+                  "path": "src/game objects/tilemap/dynamic/tile draw order.js",
                   "name": "tile draw order.js",
                   "size": 1402,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\dynamic\\weighted randomize.js",
+                  "path": "src/game objects/tilemap/dynamic/weighted randomize.js",
                   "name": "weighted randomize.js",
                   "size": 2899,
                   "extension": ".js"
@@ -6014,155 +6014,155 @@
               "size": 68869
             },
             {
-              "path": "src\\game objects\\tilemap\\static",
+              "path": "src/game objects/tilemap/static",
               "name": "static",
               "children": [
                 {
-                  "path": "src\\game objects\\tilemap\\static\\create from objects.js",
+                  "path": "src/game objects/tilemap/static/create from objects.js",
                   "name": "create from objects.js",
                   "size": 1869,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\static\\create-from-array.js",
+                  "path": "src/game objects/tilemap/static/create-from-array.js",
                   "name": "create-from-array.js",
                   "size": 1397,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\static\\csv-map.js",
+                  "path": "src/game objects/tilemap/static/csv-map.js",
                   "name": "csv-map.js",
                   "size": 1829,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\static\\danger.js",
+                  "path": "src/game objects/tilemap/static/danger.js",
                   "name": "danger.js",
                   "size": 1427,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\static\\debug colliding tiles.js",
+                  "path": "src/game objects/tilemap/static/debug colliding tiles.js",
                   "name": "debug colliding tiles.js",
                   "size": 3168,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\static\\grid movement.js",
+                  "path": "src/game objects/tilemap/static/grid movement.js",
                   "name": "grid movement.js",
                   "size": 2223,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\static\\layer size.js",
+                  "path": "src/game objects/tilemap/static/layer size.js",
                   "name": "layer size.js",
                   "size": 1556,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\static\\layer transform.js",
+                  "path": "src/game objects/tilemap/static/layer transform.js",
                   "name": "layer transform.js",
                   "size": 1181,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\static\\map vs layer with multiple layers.js",
+                  "path": "src/game objects/tilemap/static/map vs layer with multiple layers.js",
                   "name": "map vs layer with multiple layers.js",
                   "size": 3859,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\static\\mario-map-scroller.js",
+                  "path": "src/game objects/tilemap/static/mario-map-scroller.js",
                   "name": "mario-map-scroller.js",
                   "size": 1537,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\static\\multi camera map.js",
+                  "path": "src/game objects/tilemap/static/multi camera map.js",
                   "name": "multi camera map.js",
                   "size": 1617,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\static\\multiple tilesets.js",
+                  "path": "src/game objects/tilemap/static/multiple tilesets.js",
                   "name": "multiple tilesets.js",
                   "size": 2167,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\static\\pixel art test.js",
+                  "path": "src/game objects/tilemap/static/pixel art test.js",
                   "name": "pixel art test.js",
                   "size": 1245,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\static\\set colliding by collision data.js",
+                  "path": "src/game objects/tilemap/static/set colliding by collision data.js",
                   "name": "set colliding by collision data.js",
                   "size": 5109,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\static\\set colliding by property.js",
+                  "path": "src/game objects/tilemap/static/set colliding by property.js",
                   "name": "set colliding by property.js",
                   "size": 2738,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\static\\set colliding tiles.js",
+                  "path": "src/game objects/tilemap/static/set colliding tiles.js",
                   "name": "set colliding tiles.js",
                   "size": 2274,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\static\\set map size.js",
+                  "path": "src/game objects/tilemap/static/set map size.js",
                   "name": "set map size.js",
                   "size": 880,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\static\\switching tilesets.js",
+                  "path": "src/game objects/tilemap/static/switching tilesets.js",
                   "name": "switching tilesets.js",
                   "size": 5396,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\static\\tile draw order.js",
+                  "path": "src/game objects/tilemap/static/tile draw order.js",
                   "name": "tile draw order.js",
                   "size": 1400,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\static\\tile properties.js",
+                  "path": "src/game objects/tilemap/static/tile properties.js",
                   "name": "tile properties.js",
                   "size": 2074,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\static\\tiled  multi tileset.js",
+                  "path": "src/game objects/tilemap/static/tiled  multi tileset.js",
                   "name": "tiled  multi tileset.js",
                   "size": 1915,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\static\\tiled-json-map.js",
+                  "path": "src/game objects/tilemap/static/tiled-json-map.js",
                   "name": "tiled-json-map.js",
                   "size": 1709,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\static\\tileset collision shapes.js",
+                  "path": "src/game objects/tilemap/static/tileset collision shapes.js",
                   "name": "tileset collision shapes.js",
                   "size": 4007,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\static\\tileset with spacing.js",
+                  "path": "src/game objects/tilemap/static/tileset with spacing.js",
                   "name": "tileset with spacing.js",
                   "size": 1973,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\static\\zoom.js",
+                  "path": "src/game objects/tilemap/static/zoom.js",
                   "name": "zoom.js",
                   "size": 1401,
                   "extension": ".js"
@@ -6171,47 +6171,47 @@
               "size": 55951
             },
             {
-              "path": "src\\game objects\\tilemap\\tests",
+              "path": "src/game objects/tilemap/tests",
               "name": "tests",
               "children": [
                 {
-                  "path": "src\\game objects\\tilemap\\tests\\semi automated tests.js",
+                  "path": "src/game objects/tilemap/tests/semi automated tests.js",
                   "name": "semi automated tests.js",
                   "size": 55017,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\tests\\visual culling check.js",
+                  "path": "src/game objects/tilemap/tests/visual culling check.js",
                   "name": "visual culling check.js",
                   "size": 2991,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\tests\\visual face test.js",
+                  "path": "src/game objects/tilemap/tests/visual face test.js",
                   "name": "visual face test.js",
                   "size": 2934,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\tests\\visual flipping test.js",
+                  "path": "src/game objects/tilemap/tests/visual flipping test.js",
                   "name": "visual flipping test.js",
                   "size": 1396,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\tests\\visual tile bleed test.js",
+                  "path": "src/game objects/tilemap/tests/visual tile bleed test.js",
                   "name": "visual tile bleed test.js",
                   "size": 973,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\tests\\visual tile coords test.js",
+                  "path": "src/game objects/tilemap/tests/visual tile coords test.js",
                   "name": "visual tile coords test.js",
                   "size": 3769,
                   "extension": ".js"
                 },
                 {
-                  "path": "src\\game objects\\tilemap\\tests\\visual worldxy test.js",
+                  "path": "src/game objects/tilemap/tests/visual worldxy test.js",
                   "name": "visual worldxy test.js",
                   "size": 3985,
                   "extension": ".js"
@@ -6226,15 +6226,15 @@
       "size": 1022266
     },
     {
-      "path": "src\\games",
+      "path": "src/games",
       "name": "games",
       "children": [
         {
-          "path": "src\\games\\breakout",
+          "path": "src/games/breakout",
           "name": "breakout",
           "children": [
             {
-              "path": "src\\games\\breakout\\breakout.js",
+              "path": "src/games/breakout/breakout.js",
               "name": "breakout.js",
               "size": 3630,
               "extension": ".js"
@@ -6243,29 +6243,29 @@
           "size": 3630
         },
         {
-          "path": "src\\games\\cannon",
+          "path": "src/games/cannon",
           "name": "cannon",
           "children": [
             {
-              "path": "src\\games\\cannon\\babylon-math.js",
+              "path": "src/games/cannon/babylon-math.js",
               "name": "babylon-math.js",
               "size": 23160,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\cannon\\boot.json",
+              "path": "src/games/cannon/boot.json",
               "name": "boot.json",
               "size": 74,
               "extension": ".json"
             },
             {
-              "path": "src\\games\\cannon\\Game.js",
+              "path": "src/games/cannon/Game.js",
               "name": "Game.js",
               "size": 12673,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\cannon\\Test.js",
+              "path": "src/games/cannon/Test.js",
               "name": "Test.js",
               "size": 1209,
               "extension": ".js"
@@ -6274,11 +6274,11 @@
           "size": 37116
         },
         {
-          "path": "src\\games\\defenda",
+          "path": "src/games/defenda",
           "name": "defenda",
           "children": [
             {
-              "path": "src\\games\\defenda\\test.js",
+              "path": "src/games/defenda/test.js",
               "name": "test.js",
               "size": 9020,
               "extension": ".js"
@@ -6287,71 +6287,71 @@
           "size": 9020
         },
         {
-          "path": "src\\games\\firstgame",
+          "path": "src/games/firstgame",
           "name": "firstgame",
           "children": [
             {
-              "path": "src\\games\\firstgame\\assets",
+              "path": "src/games/firstgame/assets",
               "name": "assets",
               "children": [],
               "size": 0
             },
             {
-              "path": "src\\games\\firstgame\\part1.js",
+              "path": "src/games/firstgame/part1.js",
               "name": "part1.js",
               "size": 300,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\firstgame\\part10.js",
+              "path": "src/games/firstgame/part10.js",
               "name": "part10.js",
               "size": 4804,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\firstgame\\part2.js",
+              "path": "src/games/firstgame/part2.js",
               "name": "part2.js",
               "size": 692,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\firstgame\\part3.js",
+              "path": "src/games/firstgame/part3.js",
               "name": "part3.js",
               "size": 730,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\firstgame\\part4.js",
+              "path": "src/games/firstgame/part4.js",
               "name": "part4.js",
               "size": 1142,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\firstgame\\part5.js",
+              "path": "src/games/firstgame/part5.js",
               "name": "part5.js",
               "size": 1779,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\firstgame\\part6.js",
+              "path": "src/games/firstgame/part6.js",
               "name": "part6.js",
               "size": 1832,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\firstgame\\part7.js",
+              "path": "src/games/firstgame/part7.js",
               "name": "part7.js",
               "size": 2361,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\firstgame\\part8.js",
+              "path": "src/games/firstgame/part8.js",
               "name": "part8.js",
               "size": 2836,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\firstgame\\part9.js",
+              "path": "src/games/firstgame/part9.js",
               "name": "part9.js",
               "size": 3021,
               "extension": ".js"
@@ -6360,11 +6360,11 @@
           "size": 19497
         },
         {
-          "path": "src\\games\\flood",
+          "path": "src/games/flood",
           "name": "flood",
           "children": [
             {
-              "path": "src\\games\\flood\\flood-fill.js",
+              "path": "src/games/flood/flood-fill.js",
               "name": "flood-fill.js",
               "size": 19603,
               "extension": ".js"
@@ -6373,17 +6373,17 @@
           "size": 19603
         },
         {
-          "path": "src\\games\\mass attack",
+          "path": "src/games/mass attack",
           "name": "mass attack",
           "children": [
             {
-              "path": "src\\games\\mass attack\\original.js",
+              "path": "src/games/mass attack/original.js",
               "name": "original.js",
               "size": 3757,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\mass attack\\updated.js",
+              "path": "src/games/mass attack/updated.js",
               "name": "updated.js",
               "size": 3882,
               "extension": ".js"
@@ -6392,41 +6392,41 @@
           "size": 7639
         },
         {
-          "path": "src\\games\\multi",
+          "path": "src/games/multi",
           "name": "multi",
           "children": [
             {
-              "path": "src\\games\\multi\\Asteroids.js",
+              "path": "src/games/multi/Asteroids.js",
               "name": "Asteroids.js",
               "size": 916,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\multi\\boot.json",
+              "path": "src/games/multi/boot.json",
               "name": "boot.json",
               "size": 146,
               "extension": ".json"
             },
             {
-              "path": "src\\games\\multi\\Controller.js",
+              "path": "src/games/multi/Controller.js",
               "name": "Controller.js",
               "size": 627,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\multi\\Invaders.js",
+              "path": "src/games/multi/Invaders.js",
               "name": "Invaders.js",
               "size": 3488,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\multi\\main.js",
+              "path": "src/games/multi/main.js",
               "name": "main.js",
               "size": 381,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\multi\\Preloader.js",
+              "path": "src/games/multi/Preloader.js",
               "name": "Preloader.js",
               "size": 1927,
               "extension": ".js"
@@ -6435,35 +6435,35 @@
           "size": 7485
         },
         {
-          "path": "src\\games\\pacman",
+          "path": "src/games/pacman",
           "name": "pacman",
           "children": [
             {
-              "path": "src\\games\\pacman\\boot.json",
+              "path": "src/games/pacman/boot.json",
               "name": "boot.json",
               "size": 108,
               "extension": ".json"
             },
             {
-              "path": "src\\games\\pacman\\Game.js",
+              "path": "src/games/pacman/Game.js",
               "name": "Game.js",
               "size": 0,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\pacman\\MainMenu.js",
+              "path": "src/games/pacman/MainMenu.js",
               "name": "MainMenu.js",
               "size": 0,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\pacman\\UI.js",
+              "path": "src/games/pacman/UI.js",
               "name": "UI.js",
               "size": 0,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\pacman\\wip1.js",
+              "path": "src/games/pacman/wip1.js",
               "name": "wip1.js",
               "size": 29959,
               "extension": ".js"
@@ -6472,53 +6472,53 @@
           "size": 30067
         },
         {
-          "path": "src\\games\\snake",
+          "path": "src/games/snake",
           "name": "snake",
           "children": [
             {
-              "path": "src\\games\\snake\\part1.js",
+              "path": "src/games/snake/part1.js",
               "name": "part1.js",
               "size": 498,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\snake\\part2.js",
+              "path": "src/games/snake/part2.js",
               "name": "part2.js",
               "size": 4377,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\snake\\part3.js",
+              "path": "src/games/snake/part3.js",
               "name": "part3.js",
               "size": 4961,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\snake\\part4.js",
+              "path": "src/games/snake/part4.js",
               "name": "part4.js",
               "size": 5829,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\snake\\part5.js",
+              "path": "src/games/snake/part5.js",
               "name": "part5.js",
               "size": 6062,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\snake\\part6.js",
+              "path": "src/games/snake/part6.js",
               "name": "part6.js",
               "size": 7777,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\snake\\part7.js",
+              "path": "src/games/snake/part7.js",
               "name": "part7.js",
               "size": 8265,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\snake\\_part8.js",
+              "path": "src/games/snake/_part8.js",
               "name": "_part8.js",
               "size": 8969,
               "extension": ".js"
@@ -6527,29 +6527,29 @@
           "size": 46738
         },
         {
-          "path": "src\\games\\topdownShooter",
+          "path": "src/games/topdownShooter",
           "name": "topdownShooter",
           "children": [
             {
-              "path": "src\\games\\topdownShooter\\topdown_averageFocus.js",
+              "path": "src/games/topdownShooter/topdown_averageFocus.js",
               "name": "topdown_averageFocus.js",
               "size": 6651,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\topdownShooter\\topdown_combatMechanics.js",
+              "path": "src/games/topdownShooter/topdown_combatMechanics.js",
               "name": "topdown_combatMechanics.js",
               "size": 10559,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\topdownShooter\\topdown_playerFocus.js",
+              "path": "src/games/topdownShooter/topdown_playerFocus.js",
               "name": "topdown_playerFocus.js",
               "size": 5517,
               "extension": ".js"
             },
             {
-              "path": "src\\games\\topdownShooter\\topdown_targetFocus.js",
+              "path": "src/games/topdownShooter/topdown_targetFocus.js",
               "name": "topdown_targetFocus.js",
               "size": 6042,
               "extension": ".js"
@@ -6561,141 +6561,141 @@
       "size": 209564
     },
     {
-      "path": "src\\geom",
+      "path": "src/geom",
       "name": "geom",
       "children": [
         {
-          "path": "src\\geom\\circle",
+          "path": "src/geom/circle",
           "name": "circle",
           "children": [
             {
-              "path": "src\\geom\\circle\\area.js",
+              "path": "src/geom/circle/area.js",
               "name": "area.js",
               "size": 864,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\circle\\change size.js",
+              "path": "src/geom/circle/change size.js",
               "name": "change size.js",
               "size": 614,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\circle\\circumference point.js",
+              "path": "src/geom/circle/circumference point.js",
               "name": "circumference point.js",
               "size": 765,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\circle\\circumference.js",
+              "path": "src/geom/circle/circumference.js",
               "name": "circumference.js",
               "size": 916,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\circle\\clone.js",
+              "path": "src/geom/circle/clone.js",
               "name": "clone.js",
               "size": 977,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\circle\\contains point.js",
+              "path": "src/geom/circle/contains point.js",
               "name": "contains point.js",
               "size": 1041,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\circle\\contains rect.js",
+              "path": "src/geom/circle/contains rect.js",
               "name": "contains rect.js",
               "size": 995,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\circle\\contains.js",
+              "path": "src/geom/circle/contains.js",
               "name": "contains.js",
               "size": 734,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\circle\\copy from.js",
+              "path": "src/geom/circle/copy from.js",
               "name": "copy from.js",
               "size": 1130,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\circle\\create.js",
+              "path": "src/geom/circle/create.js",
               "name": "create.js",
               "size": 395,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\circle\\equals.js",
+              "path": "src/geom/circle/equals.js",
               "name": "equals.js",
               "size": 1462,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\circle\\get bounds.js",
+              "path": "src/geom/circle/get bounds.js",
               "name": "get bounds.js",
               "size": 1062,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\circle\\get point at.js",
+              "path": "src/geom/circle/get point at.js",
               "name": "get point at.js",
               "size": 867,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\circle\\get points.js",
+              "path": "src/geom/circle/get points.js",
               "name": "get points.js",
               "size": 582,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\circle\\get random point.js",
+              "path": "src/geom/circle/get random point.js",
               "name": "get random point.js",
               "size": 1039,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\circle\\is empty.js",
+              "path": "src/geom/circle/is empty.js",
               "name": "is empty.js",
               "size": 1070,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\circle\\offset point.js",
+              "path": "src/geom/circle/offset point.js",
               "name": "offset point.js",
               "size": 713,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\circle\\offset.js",
+              "path": "src/geom/circle/offset.js",
               "name": "offset.js",
               "size": 721,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\circle\\properties.js",
+              "path": "src/geom/circle/properties.js",
               "name": "properties.js",
               "size": 607,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\circle\\set empty.js",
+              "path": "src/geom/circle/set empty.js",
               "name": "set empty.js",
               "size": 1025,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\circle\\set position.js",
+              "path": "src/geom/circle/set position.js",
               "name": "set position.js",
               "size": 793,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\circle\\set to.js",
+              "path": "src/geom/circle/set to.js",
               "name": "set to.js",
               "size": 561,
               "extension": ".js"
@@ -6704,161 +6704,161 @@
           "size": 18933
         },
         {
-          "path": "src\\geom\\ellipse",
+          "path": "src/geom/ellipse",
           "name": "ellipse",
           "children": [
             {
-              "path": "src\\geom\\ellipse\\adjust size.js",
+              "path": "src/geom/ellipse/adjust size.js",
               "name": "adjust size.js",
               "size": 781,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\ellipse\\area.js",
+              "path": "src/geom/ellipse/area.js",
               "name": "area.js",
               "size": 936,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\ellipse\\circumference point.js",
+              "path": "src/geom/ellipse/circumference point.js",
               "name": "circumference point.js",
               "size": 1539,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\ellipse\\circumference.js",
+              "path": "src/geom/ellipse/circumference.js",
               "name": "circumference.js",
               "size": 1324,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\ellipse\\clone.js",
+              "path": "src/geom/ellipse/clone.js",
               "name": "clone.js",
               "size": 1107,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\ellipse\\contains point.js",
+              "path": "src/geom/ellipse/contains point.js",
               "name": "contains point.js",
               "size": 1029,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\ellipse\\contains rect.js",
+              "path": "src/geom/ellipse/contains rect.js",
               "name": "contains rect.js",
               "size": 978,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\ellipse\\contains.js",
+              "path": "src/geom/ellipse/contains.js",
               "name": "contains.js",
               "size": 767,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\ellipse\\copy from.js",
+              "path": "src/geom/ellipse/copy from.js",
               "name": "copy from.js",
               "size": 1084,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\ellipse\\create ellipse.js",
+              "path": "src/geom/ellipse/create ellipse.js",
               "name": "create ellipse.js",
               "size": 498,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\ellipse\\equals.js",
+              "path": "src/geom/ellipse/equals.js",
               "name": "equals.js",
               "size": 1577,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\ellipse\\get bounds.js",
+              "path": "src/geom/ellipse/get bounds.js",
               "name": "get bounds.js",
               "size": 1139,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\ellipse\\get major radius.js",
+              "path": "src/geom/ellipse/get major radius.js",
               "name": "get major radius.js",
               "size": 785,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\ellipse\\get minor radius.js",
+              "path": "src/geom/ellipse/get minor radius.js",
               "name": "get minor radius.js",
               "size": 785,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\ellipse\\get point at.js",
+              "path": "src/geom/ellipse/get point at.js",
               "name": "get point at.js",
               "size": 882,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\ellipse\\get points.js",
+              "path": "src/geom/ellipse/get points.js",
               "name": "get points.js",
               "size": 590,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\ellipse\\get random point.js",
+              "path": "src/geom/ellipse/get random point.js",
               "name": "get random point.js",
               "size": 1051,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\ellipse\\is empty.js",
+              "path": "src/geom/ellipse/is empty.js",
               "name": "is empty.js",
               "size": 1256,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\ellipse\\move ellipse.js",
+              "path": "src/geom/ellipse/move ellipse.js",
               "name": "move ellipse.js",
               "size": 650,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\ellipse\\offset point.js",
+              "path": "src/geom/ellipse/offset point.js",
               "name": "offset point.js",
               "size": 795,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\ellipse\\offset.js",
+              "path": "src/geom/ellipse/offset.js",
               "name": "offset.js",
               "size": 743,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\ellipse\\properties.js",
+              "path": "src/geom/ellipse/properties.js",
               "name": "properties.js",
               "size": 622,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\ellipse\\set empty.js",
+              "path": "src/geom/ellipse/set empty.js",
               "name": "set empty.js",
               "size": 1036,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\ellipse\\set position.js",
+              "path": "src/geom/ellipse/set position.js",
               "name": "set position.js",
               "size": 822,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\ellipse\\set size.js",
+              "path": "src/geom/ellipse/set size.js",
               "name": "set size.js",
               "size": 557,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\ellipse\\set to.js",
+              "path": "src/geom/ellipse/set to.js",
               "name": "set to.js",
               "size": 589,
               "extension": ".js"
@@ -6867,89 +6867,89 @@
           "size": 23922
         },
         {
-          "path": "src\\geom\\intersects",
+          "path": "src/geom/intersects",
           "name": "intersects",
           "children": [
             {
-              "path": "src\\geom\\intersects\\circle to circle.js",
+              "path": "src/geom/intersects/circle to circle.js",
               "name": "circle to circle.js",
               "size": 1150,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\intersects\\get rectangle intersection.js",
+              "path": "src/geom/intersects/get rectangle intersection.js",
               "name": "get rectangle intersection.js",
               "size": 972,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\intersects\\line to circle.js",
+              "path": "src/geom/intersects/line to circle.js",
               "name": "line to circle.js",
               "size": 1120,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\intersects\\line to line.js",
+              "path": "src/geom/intersects/line to line.js",
               "name": "line to line.js",
               "size": 1226,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\intersects\\line to rectangle.js",
+              "path": "src/geom/intersects/line to rectangle.js",
               "name": "line to rectangle.js",
               "size": 973,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\intersects\\point to line segment.js",
+              "path": "src/geom/intersects/point to line segment.js",
               "name": "point to line segment.js",
               "size": 996,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\intersects\\point to line.js",
+              "path": "src/geom/intersects/point to line.js",
               "name": "point to line.js",
               "size": 989,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\intersects\\rectangle to circle.js",
+              "path": "src/geom/intersects/rectangle to circle.js",
               "name": "rectangle to circle.js",
               "size": 1187,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\intersects\\rectangle to rectangle.js",
+              "path": "src/geom/intersects/rectangle to rectangle.js",
               "name": "rectangle to rectangle.js",
               "size": 1196,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\intersects\\rectangle to triangle.js",
+              "path": "src/geom/intersects/rectangle to triangle.js",
               "name": "rectangle to triangle.js",
               "size": 1209,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\intersects\\rectangle to values.js",
+              "path": "src/geom/intersects/rectangle to values.js",
               "name": "rectangle to values.js",
               "size": 1515,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\intersects\\triangle to circle.js",
+              "path": "src/geom/intersects/triangle to circle.js",
               "name": "triangle to circle.js",
               "size": 1176,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\intersects\\triangle to line.js",
+              "path": "src/geom/intersects/triangle to line.js",
               "name": "triangle to line.js",
               "size": 1195,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\intersects\\triangle to triangle.js",
+              "path": "src/geom/intersects/triangle to triangle.js",
               "name": "triangle to triangle.js",
               "size": 1302,
               "extension": ".js"
@@ -6958,185 +6958,185 @@
           "size": 16206
         },
         {
-          "path": "src\\geom\\line",
+          "path": "src/geom/line",
           "name": "line",
           "children": [
             {
-              "path": "src\\geom\\line\\angle.js",
+              "path": "src/geom/line/angle.js",
               "name": "angle.js",
               "size": 713,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\bresenham points.js",
+              "path": "src/geom/line/bresenham points.js",
               "name": "bresenham points.js",
               "size": 870,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\center on.js",
+              "path": "src/geom/line/center on.js",
               "name": "center on.js",
               "size": 688,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\clone.js",
+              "path": "src/geom/line/clone.js",
               "name": "clone.js",
               "size": 914,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\copy from.js",
+              "path": "src/geom/line/copy from.js",
               "name": "copy from.js",
               "size": 998,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\create.js",
+              "path": "src/geom/line/create.js",
               "name": "create.js",
               "size": 406,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\equals.js",
+              "path": "src/geom/line/equals.js",
               "name": "equals.js",
               "size": 1574,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\get mid point.js",
+              "path": "src/geom/line/get mid point.js",
               "name": "get mid point.js",
               "size": 785,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\get normal.js",
+              "path": "src/geom/line/get normal.js",
               "name": "get normal.js",
               "size": 1028,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\get point ab.js",
+              "path": "src/geom/line/get point ab.js",
               "name": "get point ab.js",
               "size": 724,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\get point at.js",
+              "path": "src/geom/line/get point at.js",
               "name": "get point at.js",
               "size": 860,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\get points.js",
+              "path": "src/geom/line/get points.js",
               "name": "get points.js",
               "size": 539,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\get random point.js",
+              "path": "src/geom/line/get random point.js",
               "name": "get random point.js",
               "size": 1030,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\height.js",
+              "path": "src/geom/line/height.js",
               "name": "height.js",
               "size": 893,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\inverse line.js",
+              "path": "src/geom/line/inverse line.js",
               "name": "inverse line.js",
               "size": 1127,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\length.js",
+              "path": "src/geom/line/length.js",
               "name": "length.js",
               "size": 889,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\normal angle.js",
+              "path": "src/geom/line/normal angle.js",
               "name": "normal angle.js",
               "size": 993,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\normal xy.js",
+              "path": "src/geom/line/normal xy.js",
               "name": "normal xy.js",
               "size": 1174,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\offset.js",
+              "path": "src/geom/line/offset.js",
               "name": "offset.js",
               "size": 788,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\perp slope.js",
+              "path": "src/geom/line/perp slope.js",
               "name": "perp slope.js",
               "size": 1471,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\point on line.js",
+              "path": "src/geom/line/point on line.js",
               "name": "point on line.js",
               "size": 579,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\properties.js",
+              "path": "src/geom/line/properties.js",
               "name": "properties.js",
               "size": 916,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\reflect angle.js",
+              "path": "src/geom/line/reflect angle.js",
               "name": "reflect angle.js",
               "size": 1404,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\rotate around point.js",
+              "path": "src/geom/line/rotate around point.js",
               "name": "rotate around point.js",
               "size": 1076,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\rotate around xy.js",
+              "path": "src/geom/line/rotate around xy.js",
               "name": "rotate around xy.js",
               "size": 677,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\rotate.js",
+              "path": "src/geom/line/rotate.js",
               "name": "rotate.js",
               "size": 544,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\set to angle.js",
+              "path": "src/geom/line/set to angle.js",
               "name": "set to angle.js",
               "size": 660,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\set to.js",
+              "path": "src/geom/line/set to.js",
               "name": "set to.js",
               "size": 557,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\slope.js",
+              "path": "src/geom/line/slope.js",
               "name": "slope.js",
               "size": 1135,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\line\\width.js",
+              "path": "src/geom/line/width.js",
               "name": "width.js",
               "size": 888,
               "extension": ".js"
@@ -7145,167 +7145,167 @@
           "size": 26900
         },
         {
-          "path": "src\\geom\\point",
+          "path": "src/geom/point",
           "name": "point",
           "children": [
             {
-              "path": "src\\geom\\point\\ceil.js",
+              "path": "src/geom/point/ceil.js",
               "name": "ceil.js",
               "size": 881,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\point\\clone.js",
+              "path": "src/geom/point/clone.js",
               "name": "clone.js",
               "size": 738,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\point\\copy from.js",
+              "path": "src/geom/point/copy from.js",
               "name": "copy from.js",
               "size": 861,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\point\\create.js",
+              "path": "src/geom/point/create.js",
               "name": "create.js",
               "size": 620,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\point\\cross.js",
+              "path": "src/geom/point/cross.js",
               "name": "cross.js",
               "size": 1514,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\point\\equals.js",
+              "path": "src/geom/point/equals.js",
               "name": "equals.js",
               "size": 1394,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\point\\floor.js",
+              "path": "src/geom/point/floor.js",
               "name": "floor.js",
               "size": 882,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\point\\get centroid.js",
+              "path": "src/geom/point/get centroid.js",
               "name": "get centroid.js",
               "size": 1362,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\point\\get magnitude sq.js",
+              "path": "src/geom/point/get magnitude sq.js",
               "name": "get magnitude sq.js",
               "size": 1298,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\point\\get magnitude.js",
+              "path": "src/geom/point/get magnitude.js",
               "name": "get magnitude.js",
               "size": 891,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\point\\get rectangle from points.js",
+              "path": "src/geom/point/get rectangle from points.js",
               "name": "get rectangle from points.js",
               "size": 1249,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\point\\interpolate.js",
+              "path": "src/geom/point/interpolate.js",
               "name": "interpolate.js",
               "size": 1136,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\point\\invert.js",
+              "path": "src/geom/point/invert.js",
               "name": "invert.js",
               "size": 750,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\point\\negative 2.js",
+              "path": "src/geom/point/negative 2.js",
               "name": "negative 2.js",
               "size": 1099,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\point\\negative.js",
+              "path": "src/geom/point/negative.js",
               "name": "negative.js",
               "size": 860,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\point\\project unit.js",
+              "path": "src/geom/point/project unit.js",
               "name": "project unit.js",
               "size": 1777,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\point\\project.js",
+              "path": "src/geom/point/project.js",
               "name": "project.js",
               "size": 1517,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\point\\set to.js",
+              "path": "src/geom/point/set to.js",
               "name": "set to.js",
               "size": 590,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\point\\_add.js",
+              "path": "src/geom/point/_add.js",
               "name": "_add.js",
               "size": 534,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\point\\_divide.js",
+              "path": "src/geom/point/_divide.js",
               "name": "_divide.js",
               "size": 762,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\point\\_dot.js",
+              "path": "src/geom/point/_dot.js",
               "name": "_dot.js",
               "size": 1947,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\point\\_multiply.js",
+              "path": "src/geom/point/_multiply.js",
               "name": "_multiply.js",
               "size": 762,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\point\\_normalize.js",
+              "path": "src/geom/point/_normalize.js",
               "name": "_normalize.js",
               "size": 1130,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\point\\_perp.js",
+              "path": "src/geom/point/_perp.js",
               "name": "_perp.js",
               "size": 1011,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\point\\_rperp.js",
+              "path": "src/geom/point/_rperp.js",
               "name": "_rperp.js",
               "size": 1012,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\point\\_set magnitude.js",
+              "path": "src/geom/point/_set magnitude.js",
               "name": "_set magnitude.js",
               "size": 833,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\point\\_subtract.js",
+              "path": "src/geom/point/_subtract.js",
               "name": "_subtract.js",
               "size": 929,
               "extension": ".js"
@@ -7314,65 +7314,65 @@
           "size": 28339
         },
         {
-          "path": "src\\geom\\polygon",
+          "path": "src/geom/polygon",
           "name": "polygon",
           "children": [
             {
-              "path": "src\\geom\\polygon\\area.js",
+              "path": "src/geom/polygon/area.js",
               "name": "area.js",
               "size": 1099,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\polygon\\basic polygon.js",
+              "path": "src/geom/polygon/basic polygon.js",
               "name": "basic polygon.js",
               "size": 736,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\polygon\\clone.js",
+              "path": "src/geom/polygon/clone.js",
               "name": "clone.js",
               "size": 1335,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\polygon\\complex polygon.js",
+              "path": "src/geom/polygon/complex polygon.js",
               "name": "complex polygon.js",
               "size": 861,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\polygon\\contains point.js",
+              "path": "src/geom/polygon/contains point.js",
               "name": "contains point.js",
               "size": 898,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\polygon\\contains.js",
+              "path": "src/geom/polygon/contains.js",
               "name": "contains.js",
               "size": 1037,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\polygon\\get aabb.js",
+              "path": "src/geom/polygon/get aabb.js",
               "name": "get aabb.js",
               "size": 1191,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\polygon\\get number array.js",
+              "path": "src/geom/polygon/get number array.js",
               "name": "get number array.js",
               "size": 1488,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\polygon\\get points.js",
+              "path": "src/geom/polygon/get points.js",
               "name": "get points.js",
               "size": 654,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\polygon\\set to.js",
+              "path": "src/geom/polygon/set to.js",
               "name": "set to.js",
               "size": 870,
               "extension": ".js"
@@ -7381,275 +7381,275 @@
           "size": 10169
         },
         {
-          "path": "src\\geom\\rectangle",
+          "path": "src/geom/rectangle",
           "name": "rectangle",
           "children": [
             {
-              "path": "src\\geom\\rectangle\\area.js",
+              "path": "src/geom/rectangle/area.js",
               "name": "area.js",
               "size": 800,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\ceil all.js",
+              "path": "src/geom/rectangle/ceil all.js",
               "name": "ceil all.js",
               "size": 788,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\ceil.js",
+              "path": "src/geom/rectangle/ceil.js",
               "name": "ceil.js",
               "size": 702,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\center on.js",
+              "path": "src/geom/rectangle/center on.js",
               "name": "center on.js",
               "size": 770,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\clone.js",
+              "path": "src/geom/rectangle/clone.js",
               "name": "clone.js",
               "size": 1110,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\contains point.js",
+              "path": "src/geom/rectangle/contains point.js",
               "name": "contains point.js",
               "size": 997,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\contains rect.js",
+              "path": "src/geom/rectangle/contains rect.js",
               "name": "contains rect.js",
               "size": 1549,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\contains.js",
+              "path": "src/geom/rectangle/contains.js",
               "name": "contains.js",
               "size": 731,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\copy from.js",
+              "path": "src/geom/rectangle/copy from.js",
               "name": "copy from.js",
               "size": 1432,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\create.js",
+              "path": "src/geom/rectangle/create.js",
               "name": "create.js",
               "size": 399,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\decompose.js",
+              "path": "src/geom/rectangle/decompose.js",
               "name": "decompose.js",
               "size": 945,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\deflate.js",
+              "path": "src/geom/rectangle/deflate.js",
               "name": "deflate.js",
               "size": 677,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\equals.js",
+              "path": "src/geom/rectangle/equals.js",
               "name": "equals.js",
               "size": 1490,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\fit inside.js",
+              "path": "src/geom/rectangle/fit inside.js",
               "name": "fit inside.js",
               "size": 1325,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\fit outside.js",
+              "path": "src/geom/rectangle/fit outside.js",
               "name": "fit outside.js",
               "size": 1393,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\floor all.js",
+              "path": "src/geom/rectangle/floor all.js",
               "name": "floor all.js",
               "size": 789,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\floor.js",
+              "path": "src/geom/rectangle/floor.js",
               "name": "floor.js",
               "size": 703,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\from points.js",
+              "path": "src/geom/rectangle/from points.js",
               "name": "from points.js",
               "size": 1175,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\get aspect ratio.js",
+              "path": "src/geom/rectangle/get aspect ratio.js",
               "name": "get aspect ratio.js",
               "size": 930,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\get center.js",
+              "path": "src/geom/rectangle/get center.js",
               "name": "get center.js",
               "size": 1742,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\get line.js",
+              "path": "src/geom/rectangle/get line.js",
               "name": "get line.js",
               "size": 1311,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\get point.js",
+              "path": "src/geom/rectangle/get point.js",
               "name": "get point.js",
               "size": 865,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\get points.js",
+              "path": "src/geom/rectangle/get points.js",
               "name": "get points.js",
               "size": 929,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\get random point outside.js",
+              "path": "src/geom/rectangle/get random point outside.js",
               "name": "get random point outside.js",
               "size": 941,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\get random point.js",
+              "path": "src/geom/rectangle/get random point.js",
               "name": "get random point.js",
               "size": 1026,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\get size.js",
+              "path": "src/geom/rectangle/get size.js",
               "name": "get size.js",
               "size": 817,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\inflate.js",
+              "path": "src/geom/rectangle/inflate.js",
               "name": "inflate.js",
               "size": 675,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\intersection.js",
+              "path": "src/geom/rectangle/intersection.js",
               "name": "intersection.js",
               "size": 1155,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\is empty.js",
+              "path": "src/geom/rectangle/is empty.js",
               "name": "is empty.js",
               "size": 806,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\marching ants.js",
+              "path": "src/geom/rectangle/marching ants.js",
               "name": "marching ants.js",
               "size": 789,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\merge points.js",
+              "path": "src/geom/rectangle/merge points.js",
               "name": "merge points.js",
               "size": 905,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\merge rect.js",
+              "path": "src/geom/rectangle/merge rect.js",
               "name": "merge rect.js",
               "size": 972,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\merge xy.js",
+              "path": "src/geom/rectangle/merge xy.js",
               "name": "merge xy.js",
               "size": 657,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\offset point.js",
+              "path": "src/geom/rectangle/offset point.js",
               "name": "offset point.js",
               "size": 710,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\offset.js",
+              "path": "src/geom/rectangle/offset.js",
               "name": "offset.js",
               "size": 556,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\overlaps.js",
+              "path": "src/geom/rectangle/overlaps.js",
               "name": "overlaps.js",
               "size": 1542,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\perimeter point.js",
+              "path": "src/geom/rectangle/perimeter point.js",
               "name": "perimeter point.js",
               "size": 1057,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\perimeter.js",
+              "path": "src/geom/rectangle/perimeter.js",
               "name": "perimeter.js",
               "size": 923,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\properties.js",
+              "path": "src/geom/rectangle/properties.js",
               "name": "properties.js",
               "size": 869,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\scale.js",
+              "path": "src/geom/rectangle/scale.js",
               "name": "scale.js",
               "size": 881,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\set empty.js",
+              "path": "src/geom/rectangle/set empty.js",
               "name": "set empty.js",
               "size": 1130,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\set position.js",
+              "path": "src/geom/rectangle/set position.js",
               "name": "set position.js",
               "size": 699,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\set size.js",
+              "path": "src/geom/rectangle/set size.js",
               "name": "set size.js",
               "size": 475,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\set to.js",
+              "path": "src/geom/rectangle/set to.js",
               "name": "set to.js",
               "size": 571,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\rectangle\\union.js",
+              "path": "src/geom/rectangle/union.js",
               "name": "union.js",
               "size": 1167,
               "extension": ".js"
@@ -7658,197 +7658,197 @@
           "size": 42875
         },
         {
-          "path": "src\\geom\\triangle",
+          "path": "src/geom/triangle",
           "name": "triangle",
           "children": [
             {
-              "path": "src\\geom\\triangle\\area.js",
+              "path": "src/geom/triangle/area.js",
               "name": "area.js",
               "size": 816,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\bottom.js",
+              "path": "src/geom/triangle/bottom.js",
               "name": "bottom.js",
               "size": 649,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\build equilateral.js",
+              "path": "src/geom/triangle/build equilateral.js",
               "name": "build equilateral.js",
               "size": 434,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\build from polygon.js",
+              "path": "src/geom/triangle/build from polygon.js",
               "name": "build from polygon.js",
               "size": 581,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\build right.js",
+              "path": "src/geom/triangle/build right.js",
               "name": "build right.js",
               "size": 433,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\center on.js",
+              "path": "src/geom/triangle/center on.js",
               "name": "center on.js",
               "size": 720,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\centroid.js",
+              "path": "src/geom/triangle/centroid.js",
               "name": "centroid.js",
               "size": 1237,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\circumcenter.js",
+              "path": "src/geom/triangle/circumcenter.js",
               "name": "circumcenter.js",
               "size": 1212,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\circumcircle.js",
+              "path": "src/geom/triangle/circumcircle.js",
               "name": "circumcircle.js",
               "size": 976,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\clone.js",
+              "path": "src/geom/triangle/clone.js",
               "name": "clone.js",
               "size": 1011,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\contains array.js",
+              "path": "src/geom/triangle/contains array.js",
               "name": "contains array.js",
               "size": 1172,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\contains point.js",
+              "path": "src/geom/triangle/contains point.js",
               "name": "contains point.js",
               "size": 781,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\contains.js",
+              "path": "src/geom/triangle/contains.js",
               "name": "contains.js",
               "size": 981,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\copy from.js",
+              "path": "src/geom/triangle/copy from.js",
               "name": "copy from.js",
               "size": 1075,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\create triangle.js",
+              "path": "src/geom/triangle/create triangle.js",
               "name": "create triangle.js",
               "size": 512,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\decompose.js",
+              "path": "src/geom/triangle/decompose.js",
               "name": "decompose.js",
               "size": 801,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\equals.js",
+              "path": "src/geom/triangle/equals.js",
               "name": "equals.js",
               "size": 1886,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\get line.js",
+              "path": "src/geom/triangle/get line.js",
               "name": "get line.js",
               "size": 617,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\get point.js",
+              "path": "src/geom/triangle/get point.js",
               "name": "get point.js",
               "size": 1335,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\get points.js",
+              "path": "src/geom/triangle/get points.js",
               "name": "get points.js",
               "size": 1391,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\get random point.js",
+              "path": "src/geom/triangle/get random point.js",
               "name": "get random point.js",
               "size": 1059,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\in center.js",
+              "path": "src/geom/triangle/in center.js",
               "name": "in center.js",
               "size": 1233,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\left.js",
+              "path": "src/geom/triangle/left.js",
               "name": "left.js",
               "size": 647,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\offset.js",
+              "path": "src/geom/triangle/offset.js",
               "name": "offset.js",
               "size": 589,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\perimeter.js",
+              "path": "src/geom/triangle/perimeter.js",
               "name": "perimeter.js",
               "size": 805,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\random.js",
+              "path": "src/geom/triangle/random.js",
               "name": "random.js",
               "size": 652,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\right.js",
+              "path": "src/geom/triangle/right.js",
               "name": "right.js",
               "size": 648,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\rotate around point.js",
+              "path": "src/geom/triangle/rotate around point.js",
               "name": "rotate around point.js",
               "size": 1357,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\rotate around xy.js",
+              "path": "src/geom/triangle/rotate around xy.js",
               "name": "rotate around xy.js",
               "size": 773,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\rotate from center.js",
+              "path": "src/geom/triangle/rotate from center.js",
               "name": "rotate from center.js",
               "size": 627,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\set to.js",
+              "path": "src/geom/triangle/set to.js",
               "name": "set to.js",
               "size": 718,
               "extension": ".js"
             },
             {
-              "path": "src\\geom\\triangle\\top.js",
+              "path": "src/geom/triangle/top.js",
               "name": "top.js",
               "size": 645,
               "extension": ".js"
@@ -7860,51 +7860,51 @@
       "size": 195717
     },
     {
-      "path": "src\\input",
+      "path": "src/input",
       "name": "input",
       "children": [
         {
-          "path": "src\\input\\camera",
+          "path": "src/input/camera",
           "name": "camera",
           "children": [
             {
-              "path": "src\\input\\camera\\camera container ignore.js",
+              "path": "src/input/camera/camera container ignore.js",
               "name": "camera container ignore.js",
               "size": 1227,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\camera\\camera ignore.js",
+              "path": "src/input/camera/camera ignore.js",
               "name": "camera ignore.js",
               "size": 985,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\camera\\graphics contains.js",
+              "path": "src/input/camera/graphics contains.js",
               "name": "graphics contains.js",
               "size": 4722,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\camera\\large world high res.js",
+              "path": "src/input/camera/large world high res.js",
               "name": "large world high res.js",
               "size": 2151,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\camera\\multi cam sprite.js",
+              "path": "src/input/camera/multi cam sprite.js",
               "name": "multi cam sprite.js",
               "size": 5686,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\camera\\stacked camera test.js",
+              "path": "src/input/camera/stacked camera test.js",
               "name": "stacked camera test.js",
               "size": 1038,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\camera\\world coordinates.js",
+              "path": "src/input/camera/world coordinates.js",
               "name": "world coordinates.js",
               "size": 1946,
               "extension": ".js"
@@ -7913,23 +7913,23 @@
           "size": 17755
         },
         {
-          "path": "src\\input\\cursors",
+          "path": "src/input/cursors",
           "name": "cursors",
           "children": [
             {
-              "path": "src\\input\\cursors\\custom cursor.js",
+              "path": "src/input/cursors/custom cursor.js",
               "name": "custom cursor.js",
               "size": 747,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\cursors\\cute cursor.js",
+              "path": "src/input/cursors/cute cursor.js",
               "name": "cute cursor.js",
               "size": 953,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\cursors\\sc2 cursors.js",
+              "path": "src/input/cursors/sc2 cursors.js",
               "name": "sc2 cursors.js",
               "size": 1728,
               "extension": ".js"
@@ -7938,17 +7938,17 @@
           "size": 3428
         },
         {
-          "path": "src\\input\\dom events",
+          "path": "src/input/dom events",
           "name": "dom events",
           "children": [
             {
-              "path": "src\\input\\dom events\\on canvas out.js",
+              "path": "src/input/dom events/on canvas out.js",
               "name": "on canvas out.js",
               "size": 818,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\dom events\\pointer button status.js",
+              "path": "src/input/dom events/pointer button status.js",
               "name": "pointer button status.js",
               "size": 798,
               "extension": ".js"
@@ -7957,95 +7957,95 @@
           "size": 1616
         },
         {
-          "path": "src\\input\\dragging",
+          "path": "src/input/dragging",
           "name": "dragging",
           "children": [
             {
-              "path": "src\\input\\dragging\\camera move and rotate.js",
+              "path": "src/input/dragging/camera move and rotate.js",
               "name": "camera move and rotate.js",
               "size": 1824,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\dragging\\drag distance threshold.js",
+              "path": "src/input/dragging/drag distance threshold.js",
               "name": "drag distance threshold.js",
               "size": 928,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\dragging\\drag time threshold.js",
+              "path": "src/input/dragging/drag time threshold.js",
               "name": "drag time threshold.js",
               "size": 930,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\dragging\\drag with multiple scenes.js",
+              "path": "src/input/dragging/drag with multiple scenes.js",
               "name": "drag with multiple scenes.js",
               "size": 1693,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\dragging\\enable for drag test 2.js",
+              "path": "src/input/dragging/enable for drag test 2.js",
               "name": "enable for drag test 2.js",
               "size": 645,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\dragging\\enable for drag.js",
+              "path": "src/input/dragging/enable for drag.js",
               "name": "enable for drag.js",
               "size": 981,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\dragging\\multi camera stack of cards.js",
+              "path": "src/input/dragging/multi camera stack of cards.js",
               "name": "multi camera stack of cards.js",
               "size": 1250,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\dragging\\multiple draggables.js",
+              "path": "src/input/dragging/multiple draggables.js",
               "name": "multiple draggables.js",
               "size": 965,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\dragging\\multiple rotated and scaled.js",
+              "path": "src/input/dragging/multiple rotated and scaled.js",
               "name": "multiple rotated and scaled.js",
               "size": 1385,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\dragging\\multiple scene drag.js",
+              "path": "src/input/dragging/multiple scene drag.js",
               "name": "multiple scene drag.js",
               "size": 2055,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\dragging\\rotated and scaled.js",
+              "path": "src/input/dragging/rotated and scaled.js",
               "name": "rotated and scaled.js",
               "size": 921,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\dragging\\scale during drag.js",
+              "path": "src/input/dragging/scale during drag.js",
               "name": "scale during drag.js",
               "size": 1250,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\dragging\\scroll factor drag.js",
+              "path": "src/input/dragging/scroll factor drag.js",
               "name": "scroll factor drag.js",
               "size": 1309,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\dragging\\scrolling text box.js",
+              "path": "src/input/dragging/scrolling text box.js",
               "name": "scrolling text box.js",
               "size": 2664,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\dragging\\stack of cards.js",
+              "path": "src/input/dragging/stack of cards.js",
               "name": "stack of cards.js",
               "size": 1017,
               "extension": ".js"
@@ -8054,113 +8054,113 @@
           "size": 19817
         },
         {
-          "path": "src\\input\\game object",
+          "path": "src/input/game object",
           "name": "game object",
           "children": [
             {
-              "path": "src\\input\\game object\\change sprite hitarea size.js",
+              "path": "src/input/game object/change sprite hitarea size.js",
               "name": "change sprite hitarea size.js",
               "size": 2835,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\game object\\custom shape hit area.js",
+              "path": "src/input/game object/custom shape hit area.js",
               "name": "custom shape hit area.js",
               "size": 1329,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\game object\\debug hitarea.js",
+              "path": "src/input/game object/debug hitarea.js",
               "name": "debug hitarea.js",
               "size": 2563,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\game object\\destroy sprite on down event.js",
+              "path": "src/input/game object/destroy sprite on down event.js",
               "name": "destroy sprite on down event.js",
               "size": 1047,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\game object\\graphics object example.js",
+              "path": "src/input/game object/graphics object example.js",
               "name": "graphics object example.js",
               "size": 1214,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\game object\\multiple down.js",
+              "path": "src/input/game object/multiple down.js",
               "name": "multiple down.js",
               "size": 2411,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\game object\\multiple over out.js",
+              "path": "src/input/game object/multiple over out.js",
               "name": "multiple over out.js",
               "size": 1089,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\game object\\multiple up.js",
+              "path": "src/input/game object/multiple up.js",
               "name": "multiple up.js",
               "size": 1165,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\game object\\on down event.js",
+              "path": "src/input/game object/on down event.js",
               "name": "on down event.js",
               "size": 844,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\game object\\on move event.js",
+              "path": "src/input/game object/on move event.js",
               "name": "on move event.js",
               "size": 502,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\game object\\on up event.js",
+              "path": "src/input/game object/on up event.js",
               "name": "on up event.js",
               "size": 500,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\game object\\over and out events.js",
+              "path": "src/input/game object/over and out events.js",
               "name": "over and out events.js",
               "size": 574,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\game object\\sprite example.js",
+              "path": "src/input/game object/sprite example.js",
               "name": "sprite example.js",
               "size": 638,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\game object\\tilesprite on down.js",
+              "path": "src/input/game object/tilesprite on down.js",
               "name": "tilesprite on down.js",
               "size": 675,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\game object\\top only over out events.js",
+              "path": "src/input/game object/top only over out events.js",
               "name": "top only over out events.js",
               "size": 1387,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\game object\\top only up down events.js",
+              "path": "src/input/game object/top only up down events.js",
               "name": "top only up down events.js",
               "size": 1034,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\game object\\use hand cursor.js",
+              "path": "src/input/game object/use hand cursor.js",
               "name": "use hand cursor.js",
               "size": 629,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\game object\\world game objects.js",
+              "path": "src/input/game object/world game objects.js",
               "name": "world game objects.js",
               "size": 2962,
               "extension": ".js"
@@ -8169,35 +8169,35 @@
           "size": 23398
         },
         {
-          "path": "src\\input\\gamepad",
+          "path": "src/input/gamepad",
           "name": "gamepad",
           "children": [
             {
-              "path": "src\\input\\gamepad\\axes.js",
+              "path": "src/input/gamepad/axes.js",
               "name": "axes.js",
               "size": 973,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\gamepad\\gamepad debug.js",
+              "path": "src/input/gamepad/gamepad debug.js",
               "name": "gamepad debug.js",
               "size": 2140,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\gamepad\\move sprite.js",
+              "path": "src/input/gamepad/move sprite.js",
               "name": "move sprite.js",
               "size": 2001,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\gamepad\\select gamepad.js",
+              "path": "src/input/gamepad/select gamepad.js",
               "name": "select gamepad.js",
               "size": 1343,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\gamepad\\twin stick shooter.js",
+              "path": "src/input/gamepad/twin stick shooter.js",
               "name": "twin stick shooter.js",
               "size": 8326,
               "extension": ".js"
@@ -8206,137 +8206,137 @@
           "size": 14783
         },
         {
-          "path": "src\\input\\keyboard",
+          "path": "src/input/keyboard",
           "name": "keyboard",
           "children": [
             {
-              "path": "src\\input\\keyboard\\add key using string.js",
+              "path": "src/input/keyboard/add key using string.js",
               "name": "add key using string.js",
               "size": 1539,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\keyboard\\add key.js",
+              "path": "src/input/keyboard/add key.js",
               "name": "add key.js",
               "size": 1678,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\keyboard\\add single key.js",
+              "path": "src/input/keyboard/add single key.js",
               "name": "add single key.js",
               "size": 4244,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\keyboard\\create key combo.js",
+              "path": "src/input/keyboard/create key combo.js",
               "name": "create key combo.js",
               "size": 596,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\keyboard\\cross scene keys.js",
+              "path": "src/input/keyboard/cross scene keys.js",
               "name": "cross scene keys.js",
               "size": 9208,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\keyboard\\cursor keys.js",
+              "path": "src/input/keyboard/cursor keys.js",
               "name": "cursor keys.js",
               "size": 1038,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\keyboard\\cursors time.js",
+              "path": "src/input/keyboard/cursors time.js",
               "name": "cursors time.js",
               "size": 2585,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\keyboard\\enter name.js",
+              "path": "src/input/keyboard/enter name.js",
               "name": "enter name.js",
               "size": 4562,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\keyboard\\global keydown event.js",
+              "path": "src/input/keyboard/global keydown event.js",
               "name": "global keydown event.js",
               "size": 368,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\keyboard\\just down.js",
+              "path": "src/input/keyboard/just down.js",
               "name": "just down.js",
               "size": 2042,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\keyboard\\key combo max key delay.js",
+              "path": "src/input/keyboard/key combo max key delay.js",
               "name": "key combo max key delay.js",
               "size": 482,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\keyboard\\key down delay.js",
+              "path": "src/input/keyboard/key down delay.js",
               "name": "key down delay.js",
               "size": 1004,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\keyboard\\key down duration.js",
+              "path": "src/input/keyboard/key down duration.js",
               "name": "key down duration.js",
               "size": 582,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\keyboard\\key modifier.js",
+              "path": "src/input/keyboard/key modifier.js",
               "name": "key modifier.js",
               "size": 620,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\keyboard\\keydown multi scene test.js",
+              "path": "src/input/keyboard/keydown multi scene test.js",
               "name": "keydown multi scene test.js",
               "size": 2967,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\keyboard\\keydown.js",
+              "path": "src/input/keyboard/keydown.js",
               "name": "keydown.js",
               "size": 1304,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\keyboard\\konami code key combo.js",
+              "path": "src/input/keyboard/konami code key combo.js",
               "name": "konami code key combo.js",
               "size": 519,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\keyboard\\numpad.js",
+              "path": "src/input/keyboard/numpad.js",
               "name": "numpad.js",
               "size": 1801,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\keyboard\\reset key combo on match.js",
+              "path": "src/input/keyboard/reset key combo on match.js",
               "name": "reset key combo on match.js",
               "size": 744,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\keyboard\\retro leaderboard.js",
+              "path": "src/input/keyboard/retro leaderboard.js",
               "name": "retro leaderboard.js",
               "size": 8461,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\keyboard\\single keydown event.js",
+              "path": "src/input/keyboard/single keydown event.js",
               "name": "single keydown event.js",
               "size": 837,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\keyboard\\text entry.js",
+              "path": "src/input/keyboard/text entry.js",
               "name": "text entry.js",
               "size": 1213,
               "extension": ".js"
@@ -8345,161 +8345,161 @@
           "size": 48394
         },
         {
-          "path": "src\\input\\mouse",
+          "path": "src/input/mouse",
           "name": "mouse",
           "children": [
             {
-              "path": "src\\input\\mouse\\check button released.js",
+              "path": "src/input/mouse/check button released.js",
               "name": "check button released.js",
               "size": 1679,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\mouse\\circle hit area.js",
+              "path": "src/input/mouse/circle hit area.js",
               "name": "circle hit area.js",
               "size": 943,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\mouse\\click sprite.js",
+              "path": "src/input/mouse/click sprite.js",
               "name": "click sprite.js",
               "size": 669,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\mouse\\ellipse hit area.js",
+              "path": "src/input/mouse/ellipse hit area.js",
               "name": "ellipse hit area.js",
               "size": 776,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\mouse\\mass scrolling sprite test no cull.js",
+              "path": "src/input/mouse/mass scrolling sprite test no cull.js",
               "name": "mass scrolling sprite test no cull.js",
               "size": 2380,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\mouse\\mass scrolling sprite test.js",
+              "path": "src/input/mouse/mass scrolling sprite test.js",
               "name": "mass scrolling sprite test.js",
               "size": 2335,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\mouse\\mass sprite test.js",
+              "path": "src/input/mouse/mass sprite test.js",
               "name": "mass sprite test.js",
               "size": 1439,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\mouse\\mouse down.js",
+              "path": "src/input/mouse/mouse down.js",
               "name": "mouse down.js",
               "size": 468,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\mouse\\mouse wheel over gameobject.js",
+              "path": "src/input/mouse/mouse wheel over gameobject.js",
               "name": "mouse wheel over gameobject.js",
               "size": 647,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\mouse\\mouse wheel.js",
+              "path": "src/input/mouse/mouse wheel.js",
               "name": "mouse wheel.js",
               "size": 692,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\mouse\\move event.js",
+              "path": "src/input/mouse/move event.js",
               "name": "move event.js",
               "size": 885,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\mouse\\origin tests.js",
+              "path": "src/input/mouse/origin tests.js",
               "name": "origin tests.js",
               "size": 1031,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\mouse\\over and out events.js",
+              "path": "src/input/mouse/over and out events.js",
               "name": "over and out events.js",
               "size": 780,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\mouse\\pointer lock.js",
+              "path": "src/input/mouse/pointer lock.js",
               "name": "pointer lock.js",
               "size": 2532,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\mouse\\poll always.js",
+              "path": "src/input/mouse/poll always.js",
               "name": "poll always.js",
               "size": 1222,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\mouse\\poll only on move.js",
+              "path": "src/input/mouse/poll only on move.js",
               "name": "poll only on move.js",
               "size": 1160,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\mouse\\polygon hit area.js",
+              "path": "src/input/mouse/polygon hit area.js",
               "name": "polygon hit area.js",
               "size": 1450,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\mouse\\right mouse button.js",
+              "path": "src/input/mouse/right mouse button.js",
               "name": "right mouse button.js",
               "size": 1642,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\mouse\\shape hit tests.js",
+              "path": "src/input/mouse/shape hit tests.js",
               "name": "shape hit tests.js",
               "size": 1805,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\mouse\\single sprite.js",
+              "path": "src/input/mouse/single sprite.js",
               "name": "single sprite.js",
               "size": 962,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\mouse\\text input test.js",
+              "path": "src/input/mouse/text input test.js",
               "name": "text input test.js",
               "size": 3483,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\mouse\\top only over and out events.js",
+              "path": "src/input/mouse/top only over and out events.js",
               "name": "top only over and out events.js",
               "size": 986,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\mouse\\top only up and down events.js",
+              "path": "src/input/mouse/top only up and down events.js",
               "name": "top only up and down events.js",
               "size": 987,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\mouse\\top only.js",
+              "path": "src/input/mouse/top only.js",
               "name": "top only.js",
               "size": 1315,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\mouse\\triangle hit area.js",
+              "path": "src/input/mouse/triangle hit area.js",
               "name": "triangle hit area.js",
               "size": 781,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\mouse\\_pointer lock 3d rotate.js",
+              "path": "src/input/mouse/_pointer lock 3d rotate.js",
               "name": "_pointer lock 3d rotate.js",
               "size": 2875,
               "extension": ".js"
@@ -8508,35 +8508,35 @@
           "size": 35924
         },
         {
-          "path": "src\\input\\multitouch",
+          "path": "src/input/multitouch",
           "name": "multitouch",
           "children": [
             {
-              "path": "src\\input\\multitouch\\multi down test.js",
+              "path": "src/input/multitouch/multi down test.js",
               "name": "multi down test.js",
               "size": 1223,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\multitouch\\multi drag.js",
+              "path": "src/input/multitouch/multi drag.js",
               "name": "multi drag.js",
               "size": 1817,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\multitouch\\multi over test.js",
+              "path": "src/input/multitouch/multi over test.js",
               "name": "multi over test.js",
               "size": 1470,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\multitouch\\multi touch test.js",
+              "path": "src/input/multitouch/multi touch test.js",
               "name": "multi touch test.js",
               "size": 2826,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\multitouch\\two touch inputs.js",
+              "path": "src/input/multitouch/two touch inputs.js",
               "name": "two touch inputs.js",
               "size": 1453,
               "extension": ".js"
@@ -8545,47 +8545,47 @@
           "size": 8789
         },
         {
-          "path": "src\\input\\pixel perfect",
+          "path": "src/input/pixel perfect",
           "name": "pixel perfect",
           "children": [
             {
-              "path": "src\\input\\pixel perfect\\atlas frame.js",
+              "path": "src/input/pixel perfect/atlas frame.js",
               "name": "atlas frame.js",
               "size": 808,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\pixel perfect\\image with lots of alpha.js",
+              "path": "src/input/pixel perfect/image with lots of alpha.js",
               "name": "image with lots of alpha.js",
               "size": 638,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\pixel perfect\\large trimmed atlas frame.js",
+              "path": "src/input/pixel perfect/large trimmed atlas frame.js",
               "name": "large trimmed atlas frame.js",
               "size": 680,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\pixel perfect\\on down.js",
+              "path": "src/input/pixel perfect/on down.js",
               "name": "on down.js",
               "size": 1165,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\pixel perfect\\on drag.js",
+              "path": "src/input/pixel perfect/on drag.js",
               "name": "on drag.js",
               "size": 1141,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\pixel perfect\\on move.js",
+              "path": "src/input/pixel perfect/on move.js",
               "name": "on move.js",
               "size": 1373,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\pixel perfect\\transformed.js",
+              "path": "src/input/pixel perfect/transformed.js",
               "name": "transformed.js",
               "size": 1205,
               "extension": ".js"
@@ -8594,77 +8594,77 @@
           "size": 7010
         },
         {
-          "path": "src\\input\\pointer",
+          "path": "src/input/pointer",
           "name": "pointer",
           "children": [
             {
-              "path": "src\\input\\pointer\\cards.js",
+              "path": "src/input/pointer/cards.js",
               "name": "cards.js",
               "size": 1063,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\pointer\\down event.js",
+              "path": "src/input/pointer/down event.js",
               "name": "down event.js",
               "size": 884,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\pointer\\drag rectangle.js",
+              "path": "src/input/pointer/drag rectangle.js",
               "name": "drag rectangle.js",
               "size": 873,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\pointer\\draw sprites.js",
+              "path": "src/input/pointer/draw sprites.js",
               "name": "draw sprites.js",
               "size": 592,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\pointer\\event list.js",
+              "path": "src/input/pointer/event list.js",
               "name": "event list.js",
               "size": 1255,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\pointer\\external link.js",
+              "path": "src/input/pointer/external link.js",
               "name": "external link.js",
               "size": 834,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\pointer\\move event.js",
+              "path": "src/input/pointer/move event.js",
               "name": "move event.js",
               "size": 537,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\pointer\\multi camera cards.js",
+              "path": "src/input/pointer/multi camera cards.js",
               "name": "multi camera cards.js",
               "size": 1503,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\pointer\\multiple scene down event.js",
+              "path": "src/input/pointer/multiple scene down event.js",
               "name": "multiple scene down event.js",
               "size": 1760,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\pointer\\pointer buttons debug.js",
+              "path": "src/input/pointer/pointer buttons debug.js",
               "name": "pointer buttons debug.js",
               "size": 1498,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\pointer\\pointer buttons.js",
+              "path": "src/input/pointer/pointer buttons.js",
               "name": "pointer buttons.js",
               "size": 1616,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\pointer\\pointer debug.js",
+              "path": "src/input/pointer/pointer debug.js",
               "name": "pointer debug.js",
               "size": 966,
               "extension": ".js"
@@ -8673,35 +8673,35 @@
           "size": 13381
         },
         {
-          "path": "src\\input\\zones",
+          "path": "src/input/zones",
           "name": "zones",
           "children": [
             {
-              "path": "src\\input\\zones\\basic input zone.js",
+              "path": "src/input/zones/basic input zone.js",
               "name": "basic input zone.js",
               "size": 1725,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\zones\\circular drop zone.js",
+              "path": "src/input/zones/circular drop zone.js",
               "name": "circular drop zone.js",
               "size": 2270,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\zones\\drop zone.js",
+              "path": "src/input/zones/drop zone.js",
               "name": "drop zone.js",
               "size": 2716,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\zones\\resize zone.js",
+              "path": "src/input/zones/resize zone.js",
               "name": "resize zone.js",
               "size": 1555,
               "extension": ".js"
             },
             {
-              "path": "src\\input\\zones\\sprite drop zone.js",
+              "path": "src/input/zones/sprite drop zone.js",
               "name": "sprite drop zone.js",
               "size": 1930,
               "extension": ".js"
@@ -8713,15 +8713,15 @@
       "size": 204491
     },
     {
-      "path": "src\\loader",
+      "path": "src/loader",
       "name": "loader",
       "children": [
         {
-          "path": "src\\loader\\animation json",
+          "path": "src/loader/animation json",
           "name": "animation json",
           "children": [
             {
-              "path": "src\\loader\\animation json\\load animation json.js",
+              "path": "src/loader/animation json/load animation json.js",
               "name": "load animation json.js",
               "size": 661,
               "extension": ".js"
@@ -8730,35 +8730,35 @@
           "size": 661
         },
         {
-          "path": "src\\loader\\audio",
+          "path": "src/loader/audio",
           "name": "audio",
           "children": [
             {
-              "path": "src\\loader\\audio\\load audio sprite resources.js",
+              "path": "src/loader/audio/load audio sprite resources.js",
               "name": "load audio sprite resources.js",
               "size": 611,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\audio\\load audio sprite.js",
+              "path": "src/loader/audio/load audio sprite.js",
               "name": "load audio sprite.js",
               "size": 686,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\audio\\load audio stream.js",
+              "path": "src/loader/audio/load audio stream.js",
               "name": "load audio stream.js",
               "size": 881,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\audio\\load audio.js",
+              "path": "src/loader/audio/load audio.js",
               "name": "load audio.js",
               "size": 861,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\audio\\load html5 audio.js",
+              "path": "src/loader/audio/load html5 audio.js",
               "name": "load html5 audio.js",
               "size": 914,
               "extension": ".js"
@@ -8767,23 +8767,23 @@
           "size": 3953
         },
         {
-          "path": "src\\loader\\binary",
+          "path": "src/loader/binary",
           "name": "binary",
           "children": [
             {
-              "path": "src\\loader\\binary\\load binary data from object.js",
+              "path": "src/loader/binary/load binary data from object.js",
               "name": "load binary data from object.js",
               "size": 1530,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\binary\\load binary data parse after load.js",
+              "path": "src/loader/binary/load binary data parse after load.js",
               "name": "load binary data parse after load.js",
               "size": 1475,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\binary\\load binary data.js",
+              "path": "src/loader/binary/load binary data.js",
               "name": "load binary data.js",
               "size": 1531,
               "extension": ".js"
@@ -8792,17 +8792,17 @@
           "size": 4536
         },
         {
-          "path": "src\\loader\\bitmap text",
+          "path": "src/loader/bitmap text",
           "name": "bitmap text",
           "children": [
             {
-              "path": "src\\loader\\bitmap text\\load bitmap text from pack.js",
+              "path": "src/loader/bitmap text/load bitmap text from pack.js",
               "name": "load bitmap text from pack.js",
               "size": 773,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\bitmap text\\load bitmap text.js",
+              "path": "src/loader/bitmap text/load bitmap text.js",
               "name": "load bitmap text.js",
               "size": 1058,
               "extension": ".js"
@@ -8811,41 +8811,41 @@
           "size": 1831
         },
         {
-          "path": "src\\loader\\file pack",
+          "path": "src/loader/file pack",
           "name": "file pack",
           "children": [
             {
-              "path": "src\\loader\\file pack\\load file pack from json.js",
+              "path": "src/loader/file pack/load file pack from json.js",
               "name": "load file pack from json.js",
               "size": 1370,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\file pack\\load file pack test 2.js",
+              "path": "src/loader/file pack/load file pack test 2.js",
               "name": "load file pack test 2.js",
               "size": 442,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\file pack\\load file pack test 3.js",
+              "path": "src/loader/file pack/load file pack test 3.js",
               "name": "load file pack test 3.js",
               "size": 535,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\file pack\\load file pack test 4.js",
+              "path": "src/loader/file pack/load file pack test 4.js",
               "name": "load file pack test 4.js",
               "size": 574,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\file pack\\load file pack test 5.js",
+              "path": "src/loader/file pack/load file pack test 5.js",
               "name": "load file pack test 5.js",
               "size": 655,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\file pack\\load file pack.js",
+              "path": "src/loader/file pack/load file pack.js",
               "name": "load file pack.js",
               "size": 453,
               "extension": ".js"
@@ -8854,17 +8854,17 @@
           "size": 4029
         },
         {
-          "path": "src\\loader\\game load config.js",
+          "path": "src/loader/game load config.js",
           "name": "game load config.js",
           "size": 6113,
           "extension": ".js"
         },
         {
-          "path": "src\\loader\\html",
+          "path": "src/loader/html",
           "name": "html",
           "children": [
             {
-              "path": "src\\loader\\html\\load html to texture.js",
+              "path": "src/loader/html/load html to texture.js",
               "name": "load html to texture.js",
               "size": 521,
               "extension": ".js"
@@ -8873,41 +8873,41 @@
           "size": 521
         },
         {
-          "path": "src\\loader\\image",
+          "path": "src/loader/image",
           "name": "image",
           "children": [
             {
-              "path": "src\\loader\\image\\load image from object.js",
+              "path": "src/loader/image/load image from object.js",
               "name": "load image from object.js",
               "size": 441,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\image\\load image on click.js",
+              "path": "src/loader/image/load image on click.js",
               "name": "load image on click.js",
               "size": 988,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\image\\load image.js",
+              "path": "src/loader/image/load image.js",
               "name": "load image.js",
               "size": 1178,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\image\\load normal map from object.js",
+              "path": "src/loader/image/load normal map from object.js",
               "name": "load normal map from object.js",
               "size": 891,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\image\\load normal map with light.js",
+              "path": "src/loader/image/load normal map with light.js",
               "name": "load normal map with light.js",
               "size": 770,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\image\\load normal map.js",
+              "path": "src/loader/image/load normal map.js",
               "name": "load normal map.js",
               "size": 837,
               "extension": ".js"
@@ -8916,89 +8916,89 @@
           "size": 5105
         },
         {
-          "path": "src\\loader\\load config tests.js",
+          "path": "src/loader/load config tests.js",
           "name": "load config tests.js",
           "size": 1819,
           "extension": ".js"
         },
         {
-          "path": "src\\loader\\load from 404.js",
+          "path": "src/loader/load from 404.js",
           "name": "load from 404.js",
           "size": 715,
           "extension": ".js"
         },
         {
-          "path": "src\\loader\\loader events",
+          "path": "src/loader/loader events",
           "name": "loader events",
           "children": [
             {
-              "path": "src\\loader\\loader events\\add files during load.js",
+              "path": "src/loader/loader events/add files during load.js",
               "name": "add files during load.js",
               "size": 7769,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\loader events\\destroy game during load.js",
+              "path": "src/loader/loader events/destroy game during load.js",
               "name": "destroy game during load.js",
               "size": 8881,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\loader events\\display file as loaded.js",
+              "path": "src/loader/loader events/display file as loaded.js",
               "name": "display file as loaded.js",
               "size": 5277,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\loader events\\file complete event with key.js",
+              "path": "src/loader/loader events/file complete event with key.js",
               "name": "file complete event with key.js",
               "size": 554,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\loader events\\file complete event.js",
+              "path": "src/loader/loader events/file complete event.js",
               "name": "file complete event.js",
               "size": 641,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\loader events\\file progress event.js",
+              "path": "src/loader/loader events/file progress event.js",
               "name": "file progress event.js",
               "size": 1090,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\loader events\\load 200 image files.js",
+              "path": "src/loader/loader events/load 200 image files.js",
               "name": "load 200 image files.js",
               "size": 7728,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\loader events\\load progress.js",
+              "path": "src/loader/loader events/load progress.js",
               "name": "load progress.js",
               "size": 8050,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\loader events\\multi file progress event.js",
+              "path": "src/loader/loader events/multi file progress event.js",
               "name": "multi file progress event.js",
               "size": 1457,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\loader events\\play animation during load.js",
+              "path": "src/loader/loader events/play animation during load.js",
               "name": "play animation during load.js",
               "size": 8455,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\loader events\\start loader manually.js",
+              "path": "src/loader/loader events/start loader manually.js",
               "name": "start loader manually.js",
               "size": 5577,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\loader events\\test loading files already loaded.js",
+              "path": "src/loader/loader events/test loading files already loaded.js",
               "name": "test loading files already loaded.js",
               "size": 2955,
               "extension": ".js"
@@ -9007,11 +9007,11 @@
           "size": 58434
         },
         {
-          "path": "src\\loader\\plugin",
+          "path": "src/loader/plugin",
           "name": "plugin",
           "children": [
             {
-              "path": "src\\loader\\plugin\\load plugin.js",
+              "path": "src/loader/plugin/load plugin.js",
               "name": "load plugin.js",
               "size": 535,
               "extension": ".js"
@@ -9020,11 +9020,11 @@
           "size": 535
         },
         {
-          "path": "src\\loader\\scene",
+          "path": "src/loader/scene",
           "name": "scene",
           "children": [
             {
-              "path": "src\\loader\\scene\\load scene.js",
+              "path": "src/loader/scene/load scene.js",
               "name": "load scene.js",
               "size": 675,
               "extension": ".js"
@@ -9033,11 +9033,11 @@
           "size": 675
         },
         {
-          "path": "src\\loader\\scene payload",
+          "path": "src/loader/scene payload",
           "name": "scene payload",
           "children": [
             {
-              "path": "src\\loader\\scene payload\\scene files payload.js",
+              "path": "src/loader/scene payload/scene files payload.js",
               "name": "scene files payload.js",
               "size": 1434,
               "extension": ".js"
@@ -9046,11 +9046,11 @@
           "size": 1434
         },
         {
-          "path": "src\\loader\\script",
+          "path": "src/loader/script",
           "name": "script",
           "children": [
             {
-              "path": "src\\loader\\script\\load script.js",
+              "path": "src/loader/script/load script.js",
               "name": "load script.js",
               "size": 841,
               "extension": ".js"
@@ -9059,29 +9059,29 @@
           "size": 841
         },
         {
-          "path": "src\\loader\\sprite sheet",
+          "path": "src/loader/sprite sheet",
           "name": "sprite sheet",
           "children": [
             {
-              "path": "src\\loader\\sprite sheet\\load sprite sheet from object array.js",
+              "path": "src/loader/sprite sheet/load sprite sheet from object array.js",
               "name": "load sprite sheet from object array.js",
               "size": 1024,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\sprite sheet\\load sprite sheet from object.js",
+              "path": "src/loader/sprite sheet/load sprite sheet from object.js",
               "name": "load sprite sheet from object.js",
               "size": 770,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\sprite sheet\\load sprite sheet from scene payload.js",
+              "path": "src/loader/sprite sheet/load sprite sheet from scene payload.js",
               "name": "load sprite sheet from scene payload.js",
               "size": 858,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\sprite sheet\\load sprite sheet.js",
+              "path": "src/loader/sprite sheet/load sprite sheet.js",
               "name": "load sprite sheet.js",
               "size": 859,
               "extension": ".js"
@@ -9090,23 +9090,23 @@
           "size": 3511
         },
         {
-          "path": "src\\loader\\svg",
+          "path": "src/loader/svg",
           "name": "svg",
           "children": [
             {
-              "path": "src\\loader\\svg\\load svg with fixed size.js",
+              "path": "src/loader/svg/load svg with fixed size.js",
               "name": "load svg with fixed size.js",
               "size": 660,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\svg\\load svg with scale.js",
+              "path": "src/loader/svg/load svg with scale.js",
               "name": "load svg with scale.js",
               "size": 2304,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\svg\\load svg.js",
+              "path": "src/loader/svg/load svg.js",
               "name": "load svg.js",
               "size": 908,
               "extension": ".js"
@@ -9115,65 +9115,65 @@
           "size": 3872
         },
         {
-          "path": "src\\loader\\texture atlas json",
+          "path": "src/loader/texture atlas json",
           "name": "texture atlas json",
           "children": [
             {
-              "path": "src\\loader\\texture atlas json\\get atlas custom frame data.js",
+              "path": "src/loader/texture atlas json/get atlas custom frame data.js",
               "name": "get atlas custom frame data.js",
               "size": 2501,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\texture atlas json\\get atlas meta data.js",
+              "path": "src/loader/texture atlas json/get atlas meta data.js",
               "name": "get atlas meta data.js",
               "size": 8089,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\texture atlas json\\load atlas with local json.js",
+              "path": "src/loader/texture atlas json/load atlas with local json.js",
               "name": "load atlas with local json.js",
               "size": 7571,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\texture atlas json\\load texture atlas from object.js",
+              "path": "src/loader/texture atlas json/load texture atlas from object.js",
               "name": "load texture atlas from object.js",
               "size": 747,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\texture atlas json\\load texture atlas from pack.js",
+              "path": "src/loader/texture atlas json/load texture atlas from pack.js",
               "name": "load texture atlas from pack.js",
               "size": 653,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\texture atlas json\\load texture atlas from payload.js",
+              "path": "src/loader/texture atlas json/load texture atlas from payload.js",
               "name": "load texture atlas from payload.js",
               "size": 739,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\texture atlas json\\load texture atlas with normal map from object.js",
+              "path": "src/loader/texture atlas json/load texture atlas with normal map from object.js",
               "name": "load texture atlas with normal map from object.js",
               "size": 1195,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\texture atlas json\\load texture atlas with normal map.js",
+              "path": "src/loader/texture atlas json/load texture atlas with normal map.js",
               "name": "load texture atlas with normal map.js",
               "size": 1116,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\texture atlas json\\load texture atlas.js",
+              "path": "src/loader/texture atlas json/load texture atlas.js",
               "name": "load texture atlas.js",
               "size": 684,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\texture atlas json\\mixed json test.js",
+              "path": "src/loader/texture atlas json/mixed json test.js",
               "name": "mixed json test.js",
               "size": 7759,
               "extension": ".js"
@@ -9182,17 +9182,17 @@
           "size": 31054
         },
         {
-          "path": "src\\loader\\texture atlas multi",
+          "path": "src/loader/texture atlas multi",
           "name": "texture atlas multi",
           "children": [
             {
-              "path": "src\\loader\\texture atlas multi\\load multi texture atlas with normal maps.js",
+              "path": "src/loader/texture atlas multi/load multi texture atlas with normal maps.js",
               "name": "load multi texture atlas with normal maps.js",
               "size": 1078,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\texture atlas multi\\load multi texture atlas.js",
+              "path": "src/loader/texture atlas multi/load multi texture atlas.js",
               "name": "load multi texture atlas.js",
               "size": 838,
               "extension": ".js"
@@ -9201,17 +9201,17 @@
           "size": 1916
         },
         {
-          "path": "src\\loader\\texture atlas unity",
+          "path": "src/loader/texture atlas unity",
           "name": "texture atlas unity",
           "children": [
             {
-              "path": "src\\loader\\texture atlas unity\\load unity spritesheet animation.js",
+              "path": "src/loader/texture atlas unity/load unity spritesheet animation.js",
               "name": "load unity spritesheet animation.js",
               "size": 1137,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\texture atlas unity\\load unity spritesheet.js",
+              "path": "src/loader/texture atlas unity/load unity spritesheet.js",
               "name": "load unity spritesheet.js",
               "size": 743,
               "extension": ".js"
@@ -9220,11 +9220,11 @@
           "size": 1880
         },
         {
-          "path": "src\\loader\\texture atlas xml",
+          "path": "src/loader/texture atlas xml",
           "name": "texture atlas xml",
           "children": [
             {
-              "path": "src\\loader\\texture atlas xml\\load xml texture atlas.js",
+              "path": "src/loader/texture atlas xml/load xml texture atlas.js",
               "name": "load xml texture atlas.js",
               "size": 671,
               "extension": ".js"
@@ -9233,35 +9233,35 @@
           "size": 671
         },
         {
-          "path": "src\\loader\\tile maps",
+          "path": "src/loader/tile maps",
           "name": "tile maps",
           "children": [
             {
-              "path": "src\\loader\\tile maps\\load tile map from local json.js",
+              "path": "src/loader/tile maps/load tile map from local json.js",
               "name": "load tile map from local json.js",
               "size": 23985,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\tile maps\\load tile map json from object.js",
+              "path": "src/loader/tile maps/load tile map json from object.js",
               "name": "load tile map json from object.js",
               "size": 1228,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\tile maps\\load tile map json from scene payload.js",
+              "path": "src/loader/tile maps/load tile map json from scene payload.js",
               "name": "load tile map json from scene payload.js",
               "size": 1405,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\tile maps\\load tile map json with normal map.js",
+              "path": "src/loader/tile maps/load tile map json with normal map.js",
               "name": "load tile map json with normal map.js",
               "size": 1566,
               "extension": ".js"
             },
             {
-              "path": "src\\loader\\tile maps\\load tile map json.js",
+              "path": "src/loader/tile maps/load tile map json.js",
               "name": "load tile map json.js",
               "size": 1189,
               "extension": ".js"
@@ -9273,189 +9273,189 @@
       "size": 163479
     },
     {
-      "path": "src\\paths",
+      "path": "src/paths",
       "name": "paths",
       "children": [
         {
-          "path": "src\\paths\\all types.js",
+          "path": "src/paths/all types.js",
           "name": "all types.js",
           "size": 1204,
           "extension": ".js"
         },
         {
-          "path": "src\\paths\\circle loop path.js",
+          "path": "src/paths/circle loop path.js",
           "name": "circle loop path.js",
           "size": 1033,
           "extension": ".js"
         },
         {
-          "path": "src\\paths\\circle path.js",
+          "path": "src/paths/circle path.js",
           "name": "circle path.js",
           "size": 965,
           "extension": ".js"
         },
         {
-          "path": "src\\paths\\complex path bounds.js",
+          "path": "src/paths/complex path bounds.js",
           "name": "complex path bounds.js",
           "size": 1387,
           "extension": ".js"
         },
         {
-          "path": "src\\paths\\curves",
+          "path": "src/paths/curves",
           "name": "curves",
           "children": [
             {
-              "path": "src\\paths\\curves\\cubic bezier bounds.js",
+              "path": "src/paths/curves/cubic bezier bounds.js",
               "name": "cubic bezier bounds.js",
               "size": 3151,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\curves\\cubic bezier curve debug.js",
+              "path": "src/paths/curves/cubic bezier curve debug.js",
               "name": "cubic bezier curve debug.js",
               "size": 2929,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\curves\\cubic bezier curve.js",
+              "path": "src/paths/curves/cubic bezier curve.js",
               "name": "cubic bezier curve.js",
               "size": 1174,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\curves\\drag cubic bezier curve.js",
+              "path": "src/paths/curves/drag cubic bezier curve.js",
               "name": "drag cubic bezier curve.js",
               "size": 2933,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\curves\\drag ellipse curve.js",
+              "path": "src/paths/curves/drag ellipse curve.js",
               "name": "drag ellipse curve.js",
               "size": 5157,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\curves\\drag line curve.js",
+              "path": "src/paths/curves/drag line curve.js",
               "name": "drag line curve.js",
               "size": 1932,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\curves\\drag quadratic bezier curve.js",
+              "path": "src/paths/curves/drag quadratic bezier curve.js",
               "name": "drag quadratic bezier curve.js",
               "size": 2666,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\curves\\drag spline curve.js",
+              "path": "src/paths/curves/drag spline curve.js",
               "name": "drag spline curve.js",
               "size": 1938,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\curves\\ellipse curve bounds.js",
+              "path": "src/paths/curves/ellipse curve bounds.js",
               "name": "ellipse curve bounds.js",
               "size": 4769,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\curves\\ellipse curve.js",
+              "path": "src/paths/curves/ellipse curve.js",
               "name": "ellipse curve.js",
               "size": 1385,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\curves\\get distance on line curve.js",
+              "path": "src/paths/curves/get distance on line curve.js",
               "name": "get distance on line curve.js",
               "size": 745,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\curves\\get points on cubic bezier curve.js",
+              "path": "src/paths/curves/get points on cubic bezier curve.js",
               "name": "get points on cubic bezier curve.js",
               "size": 895,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\curves\\get points on line curve.js",
+              "path": "src/paths/curves/get points on line curve.js",
               "name": "get points on line curve.js",
               "size": 741,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\curves\\get spaced points on cubic bezier curve.js",
+              "path": "src/paths/curves/get spaced points on cubic bezier curve.js",
               "name": "get spaced points on cubic bezier curve.js",
               "size": 921,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\curves\\get spaced points on line curve.js",
+              "path": "src/paths/curves/get spaced points on line curve.js",
               "name": "get spaced points on line curve.js",
               "size": 747,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\curves\\get tangent vectors on cubic bezier curve.js",
+              "path": "src/paths/curves/get tangent vectors on cubic bezier curve.js",
               "name": "get tangent vectors on cubic bezier curve.js",
               "size": 1494,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\curves\\line curve bounds.js",
+              "path": "src/paths/curves/line curve bounds.js",
               "name": "line curve bounds.js",
               "size": 2223,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\curves\\line curve.js",
+              "path": "src/paths/curves/line curve.js",
               "name": "line curve.js",
               "size": 952,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\curves\\point types.js",
+              "path": "src/paths/curves/point types.js",
               "name": "point types.js",
               "size": 1025,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\curves\\quadratic bezier curve.js",
+              "path": "src/paths/curves/quadratic bezier curve.js",
               "name": "quadratic bezier curve.js",
               "size": 1103,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\curves\\rectangle spline intersection.js",
+              "path": "src/paths/curves/rectangle spline intersection.js",
               "name": "rectangle spline intersection.js",
               "size": 4705,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\curves\\spline builder.js",
+              "path": "src/paths/curves/spline builder.js",
               "name": "spline builder.js",
               "size": 2554,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\curves\\spline curve bounds.js",
+              "path": "src/paths/curves/spline curve bounds.js",
               "name": "spline curve bounds.js",
               "size": 2234,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\curves\\spline curve distance points.js",
+              "path": "src/paths/curves/spline curve distance points.js",
               "name": "spline curve distance points.js",
               "size": 1058,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\curves\\spline curve from array.js",
+              "path": "src/paths/curves/spline curve from array.js",
               "name": "spline curve from array.js",
               "size": 1206,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\curves\\spline curve.js",
+              "path": "src/paths/curves/spline curve.js",
               "name": "spline curve.js",
               "size": 1354,
               "extension": ".js"
@@ -9464,83 +9464,83 @@
           "size": 51991
         },
         {
-          "path": "src\\paths\\followers",
+          "path": "src/paths/followers",
           "name": "followers",
           "children": [
             {
-              "path": "src\\paths\\followers\\basic follower.js",
+              "path": "src/paths/followers/basic follower.js",
               "name": "basic follower.js",
               "size": 1126,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\followers\\change path.js",
+              "path": "src/paths/followers/change path.js",
               "name": "change path.js",
               "size": 1501,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\followers\\mass followers.js",
+              "path": "src/paths/followers/mass followers.js",
               "name": "mass followers.js",
               "size": 1116,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\followers\\multi curve path.js",
+              "path": "src/paths/followers/multi curve path.js",
               "name": "multi curve path.js",
               "size": 1054,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\followers\\path from json all types.js",
+              "path": "src/paths/followers/path from json all types.js",
               "name": "path from json all types.js",
               "size": 929,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\followers\\path from json.js",
+              "path": "src/paths/followers/path from json.js",
               "name": "path from json.js",
               "size": 903,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\followers\\pause and resume.js",
+              "path": "src/paths/followers/pause and resume.js",
               "name": "pause and resume.js",
               "size": 1426,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\followers\\rotate to path.js",
+              "path": "src/paths/followers/rotate to path.js",
               "name": "rotate to path.js",
               "size": 1209,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\followers\\rotation offset.js",
+              "path": "src/paths/followers/rotation offset.js",
               "name": "rotation offset.js",
               "size": 832,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\followers\\sparkle trail.js",
+              "path": "src/paths/followers/sparkle trail.js",
               "name": "sparkle trail.js",
               "size": 1089,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\followers\\start at.js",
+              "path": "src/paths/followers/start at.js",
               "name": "start at.js",
               "size": 1449,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\followers\\wave path.js",
+              "path": "src/paths/followers/wave path.js",
               "name": "wave path.js",
               "size": 1505,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\followers\\yoyo follower.js",
+              "path": "src/paths/followers/yoyo follower.js",
               "name": "yoyo follower.js",
               "size": 998,
               "extension": ".js"
@@ -9549,47 +9549,47 @@
           "size": 15137
         },
         {
-          "path": "src\\paths\\line to ellipse.js",
+          "path": "src/paths/line to ellipse.js",
           "name": "line to ellipse.js",
           "size": 1173,
           "extension": ".js"
         },
         {
-          "path": "src\\paths\\move to.js",
+          "path": "src/paths/move to.js",
           "name": "move to.js",
           "size": 1110,
           "extension": ".js"
         },
         {
-          "path": "src\\paths\\path add line curve.js",
+          "path": "src/paths/path add line curve.js",
           "name": "path add line curve.js",
           "size": 1034,
           "extension": ".js"
         },
         {
-          "path": "src\\paths\\path bounds.js",
+          "path": "src/paths/path bounds.js",
           "name": "path bounds.js",
           "size": 1305,
           "extension": ".js"
         },
         {
-          "path": "src\\paths\\path editor",
+          "path": "src/paths/path editor",
           "name": "path editor",
           "children": [
             {
-              "path": "src\\paths\\path editor\\boot.json",
+              "path": "src/paths/path editor/boot.json",
               "name": "boot.json",
               "size": 72,
               "extension": ".json"
             },
             {
-              "path": "src\\paths\\path editor\\Controller.js",
+              "path": "src/paths/path editor/Controller.js",
               "name": "Controller.js",
               "size": 334,
               "extension": ".js"
             },
             {
-              "path": "src\\paths\\path editor\\main.js",
+              "path": "src/paths/path editor/main.js",
               "name": "main.js",
               "size": 363,
               "extension": ".js"
@@ -9598,25 +9598,25 @@
           "size": 769
         },
         {
-          "path": "src\\paths\\path line and bezier.js",
+          "path": "src/paths/path line and bezier.js",
           "name": "path line and bezier.js",
           "size": 1115,
           "extension": ".js"
         },
         {
-          "path": "src\\paths\\simple path.js",
+          "path": "src/paths/simple path.js",
           "name": "simple path.js",
           "size": 1165,
           "extension": ".js"
         },
         {
-          "path": "src\\paths\\velocity from tangent vectors.js",
+          "path": "src/paths/velocity from tangent vectors.js",
           "name": "velocity from tangent vectors.js",
           "size": 2271,
           "extension": ".js"
         },
         {
-          "path": "src\\paths\\zig zag path.js",
+          "path": "src/paths/zig zag path.js",
           "name": "zig zag path.js",
           "size": 1816,
           "extension": ".js"
@@ -9625,471 +9625,471 @@
       "size": 83475
     },
     {
-      "path": "src\\physics",
+      "path": "src/physics",
       "name": "physics",
       "children": [
         {
-          "path": "src\\physics\\arcade",
+          "path": "src/physics/arcade",
           "name": "arcade",
           "children": [
             {
-              "path": "src\\physics\\arcade\\100 world bodies.js",
+              "path": "src/physics/arcade/100 world bodies.js",
               "name": "100 world bodies.js",
               "size": 2771,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\1000 world bodies.js",
+              "path": "src/physics/arcade/1000 world bodies.js",
               "name": "1000 world bodies.js",
               "size": 2772,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\10000 world bodies.js",
+              "path": "src/physics/arcade/10000 world bodies.js",
               "name": "10000 world bodies.js",
               "size": 2796,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\40000 world bodies.js",
+              "path": "src/physics/arcade/40000 world bodies.js",
               "name": "40000 world bodies.js",
               "size": 2586,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\accelerate to.js",
+              "path": "src/physics/arcade/accelerate to.js",
               "name": "accelerate to.js",
               "size": 1017,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\add body to tilesprite.js",
+              "path": "src/physics/arcade/add body to tilesprite.js",
               "name": "add body to tilesprite.js",
               "size": 1033,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\angular acceleration.js",
+              "path": "src/physics/arcade/angular acceleration.js",
               "name": "angular acceleration.js",
               "size": 872,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\angular velocity.js",
+              "path": "src/physics/arcade/angular velocity.js",
               "name": "angular velocity.js",
               "size": 1141,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\asteroids movement.js",
+              "path": "src/physics/arcade/asteroids movement.js",
               "name": "asteroids movement.js",
               "size": 1627,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\basic platform.js",
+              "path": "src/physics/arcade/basic platform.js",
               "name": "basic platform.js",
               "size": 3322,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\body controls.js",
+              "path": "src/physics/arcade/body controls.js",
               "name": "body controls.js",
               "size": 2550,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\body on a path.js",
+              "path": "src/physics/arcade/body on a path.js",
               "name": "body on a path.js",
               "size": 3855,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\body stack test 10.js",
+              "path": "src/physics/arcade/body stack test 10.js",
               "name": "body stack test 10.js",
               "size": 10346,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\body stack test 2.js",
+              "path": "src/physics/arcade/body stack test 2.js",
               "name": "body stack test 2.js",
               "size": 3007,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\body stack test 3.js",
+              "path": "src/physics/arcade/body stack test 3.js",
               "name": "body stack test 3.js",
               "size": 825,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\body stack test 4.js",
+              "path": "src/physics/arcade/body stack test 4.js",
               "name": "body stack test 4.js",
               "size": 4173,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\body stack test 5.js",
+              "path": "src/physics/arcade/body stack test 5.js",
               "name": "body stack test 5.js",
               "size": 8531,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\body stack test 5B.js",
+              "path": "src/physics/arcade/body stack test 5B.js",
               "name": "body stack test 5B.js",
               "size": 2897,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\body stack test 6.js",
+              "path": "src/physics/arcade/body stack test 6.js",
               "name": "body stack test 6.js",
               "size": 8479,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\body stack test 7.js",
+              "path": "src/physics/arcade/body stack test 7.js",
               "name": "body stack test 7.js",
               "size": 8582,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\body stack test 8.js",
+              "path": "src/physics/arcade/body stack test 8.js",
               "name": "body stack test 8.js",
               "size": 9474,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\body stack test 9.js",
+              "path": "src/physics/arcade/body stack test 9.js",
               "name": "body stack test 9.js",
               "size": 9621,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\body stack test.js",
+              "path": "src/physics/arcade/body stack test.js",
               "name": "body stack test.js",
               "size": 7968,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\bounce test.js",
+              "path": "src/physics/arcade/bounce test.js",
               "name": "bounce test.js",
               "size": 1856,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\bullets group.js",
+              "path": "src/physics/arcade/bullets group.js",
               "name": "bullets group.js",
               "size": 2019,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\circular body.js",
+              "path": "src/physics/arcade/circular body.js",
               "name": "circular body.js",
               "size": 907,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\closest furthest.js",
+              "path": "src/physics/arcade/closest furthest.js",
               "name": "closest furthest.js",
               "size": 1591,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\collider 1.js",
+              "path": "src/physics/arcade/collider 1.js",
               "name": "collider 1.js",
               "size": 1173,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\custom debug colors.js",
+              "path": "src/physics/arcade/custom debug colors.js",
               "name": "custom debug colors.js",
               "size": 2982,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\custom separate.js",
+              "path": "src/physics/arcade/custom separate.js",
               "name": "custom separate.js",
               "size": 1227,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\debug face.js",
+              "path": "src/physics/arcade/debug face.js",
               "name": "debug face.js",
               "size": 8909,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\destroy body.js",
+              "path": "src/physics/arcade/destroy body.js",
               "name": "destroy body.js",
               "size": 1168,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\drag through open face.js",
+              "path": "src/physics/arcade/drag through open face.js",
               "name": "drag through open face.js",
               "size": 7931,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\draggable body.js",
+              "path": "src/physics/arcade/draggable body.js",
               "name": "draggable body.js",
               "size": 1023,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\extending arcade sprite.js",
+              "path": "src/physics/arcade/extending arcade sprite.js",
               "name": "extending arcade sprite.js",
               "size": 1855,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\fast moving body test 2.js",
+              "path": "src/physics/arcade/fast moving body test 2.js",
               "name": "fast moving body test 2.js",
               "size": 5477,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\fast moving body test.js",
+              "path": "src/physics/arcade/fast moving body test.js",
               "name": "fast moving body test.js",
               "size": 5211,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\fps test.js",
+              "path": "src/physics/arcade/fps test.js",
               "name": "fps test.js",
               "size": 1231,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\friction.js",
+              "path": "src/physics/arcade/friction.js",
               "name": "friction.js",
               "size": 1471,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\get bodies within rectangle.js",
+              "path": "src/physics/arcade/get bodies within rectangle.js",
               "name": "get bodies within rectangle.js",
               "size": 1843,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\gravity.js",
+              "path": "src/physics/arcade/gravity.js",
               "name": "gravity.js",
               "size": 857,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\group set velocity x.js",
+              "path": "src/physics/arcade/group set velocity x.js",
               "name": "group set velocity x.js",
               "size": 851,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\group set velocity y.js",
+              "path": "src/physics/arcade/group set velocity y.js",
               "name": "group set velocity y.js",
               "size": 824,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\larger bounding box.js",
+              "path": "src/physics/arcade/larger bounding box.js",
               "name": "larger bounding box.js",
               "size": 1149,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\mass collision test.js",
+              "path": "src/physics/arcade/mass collision test.js",
               "name": "mass collision test.js",
               "size": 2407,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\mass.js",
+              "path": "src/physics/arcade/mass.js",
               "name": "mass.js",
               "size": 1248,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\move and stop at position.js",
+              "path": "src/physics/arcade/move and stop at position.js",
               "name": "move and stop at position.js",
               "size": 1597,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\move through open face.js",
+              "path": "src/physics/arcade/move through open face.js",
               "name": "move through open face.js",
               "size": 1477,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\move to pointer.js",
+              "path": "src/physics/arcade/move to pointer.js",
               "name": "move to pointer.js",
               "size": 1150,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\move to.js",
+              "path": "src/physics/arcade/move to.js",
               "name": "move to.js",
               "size": 1028,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\non rendering body.js",
+              "path": "src/physics/arcade/non rendering body.js",
               "name": "non rendering body.js",
               "size": 4145,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\one way collision.js",
+              "path": "src/physics/arcade/one way collision.js",
               "name": "one way collision.js",
               "size": 3007,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\overlap collider.js",
+              "path": "src/physics/arcade/overlap collider.js",
               "name": "overlap collider.js",
               "size": 1129,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\overlap zone.js",
+              "path": "src/physics/arcade/overlap zone.js",
               "name": "overlap zone.js",
               "size": 1158,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\remove collider.js",
+              "path": "src/physics/arcade/remove collider.js",
               "name": "remove collider.js",
               "size": 1248,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\restart physics scene.js",
+              "path": "src/physics/arcade/restart physics scene.js",
               "name": "restart physics scene.js",
               "size": 5609,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\rtree test.js",
+              "path": "src/physics/arcade/rtree test.js",
               "name": "rtree test.js",
               "size": 1462,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\simple body.js",
+              "path": "src/physics/arcade/simple body.js",
               "name": "simple body.js",
               "size": 642,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\simple group.js",
+              "path": "src/physics/arcade/simple group.js",
               "name": "simple group.js",
               "size": 948,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\smaller bounding box.js",
+              "path": "src/physics/arcade/smaller bounding box.js",
               "name": "smaller bounding box.js",
               "size": 974,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\space.js",
+              "path": "src/physics/arcade/space.js",
               "name": "space.js",
               "size": 7685,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\sprite overlap group.js",
+              "path": "src/physics/arcade/sprite overlap group.js",
               "name": "sprite overlap group.js",
               "size": 2876,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\sprite vs group.js",
+              "path": "src/physics/arcade/sprite vs group.js",
               "name": "sprite vs group.js",
               "size": 1030,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\sprite vs immovable.js",
+              "path": "src/physics/arcade/sprite vs immovable.js",
               "name": "sprite vs immovable.js",
               "size": 921,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\sprite vs multiple groups.js",
+              "path": "src/physics/arcade/sprite vs multiple groups.js",
               "name": "sprite vs multiple groups.js",
               "size": 1725,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\sprite vs sprite.js",
+              "path": "src/physics/arcade/sprite vs sprite.js",
               "name": "sprite vs sprite.js",
               "size": 952,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\static body update.js",
+              "path": "src/physics/arcade/static body update.js",
               "name": "static body update.js",
               "size": 1232,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\static body.js",
+              "path": "src/physics/arcade/static body.js",
               "name": "static body.js",
               "size": 1061,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\static group.js",
+              "path": "src/physics/arcade/static group.js",
               "name": "static group.js",
               "size": 1226,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\tween body.js",
+              "path": "src/physics/arcade/tween body.js",
               "name": "tween body.js",
               "size": 1028,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\tween velocity.js",
+              "path": "src/physics/arcade/tween velocity.js",
               "name": "tween velocity.js",
               "size": 3449,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\velocity from angle.js",
+              "path": "src/physics/arcade/velocity from angle.js",
               "name": "velocity from angle.js",
               "size": 2047,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\vertical friction.js",
+              "path": "src/physics/arcade/vertical friction.js",
               "name": "vertical friction.js",
               "size": 1083,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\world bounds event.js",
+              "path": "src/physics/arcade/world bounds event.js",
               "name": "world bounds event.js",
               "size": 1276,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\world controls.js",
+              "path": "src/physics/arcade/world controls.js",
               "name": "world controls.js",
               "size": 3022,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\wrap group.js",
+              "path": "src/physics/arcade/wrap group.js",
               "name": "wrap group.js",
               "size": 1641,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\arcade\\wrap sprite.js",
+              "path": "src/physics/arcade/wrap sprite.js",
               "name": "wrap sprite.js",
               "size": 673,
               "extension": ".js"
@@ -10098,173 +10098,173 @@
           "size": 213956
         },
         {
-          "path": "src\\physics\\impact",
+          "path": "src/physics/impact",
           "name": "impact",
           "children": [
             {
-              "path": "src\\physics\\impact\\100 world bodies.js",
+              "path": "src/physics/impact/100 world bodies.js",
               "name": "100 world bodies.js",
               "size": 2953,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\impact\\1000 world bodies.js",
+              "path": "src/physics/impact/1000 world bodies.js",
               "name": "1000 world bodies.js",
               "size": 2983,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\impact\\10000 world bodies.js",
+              "path": "src/physics/impact/10000 world bodies.js",
               "name": "10000 world bodies.js",
               "size": 2985,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\impact\\bitmaptext body.js",
+              "path": "src/physics/impact/bitmaptext body.js",
               "name": "bitmaptext body.js",
               "size": 1050,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\impact\\body collision.js",
+              "path": "src/physics/impact/body collision.js",
               "name": "body collision.js",
               "size": 826,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\impact\\body offset.js",
+              "path": "src/physics/impact/body offset.js",
               "name": "body offset.js",
               "size": 908,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\impact\\collide callback.js",
+              "path": "src/physics/impact/collide callback.js",
               "name": "collide callback.js",
               "size": 961,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\impact\\collide event.js",
+              "path": "src/physics/impact/collide event.js",
               "name": "collide event.js",
               "size": 1074,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\impact\\collision map.js",
+              "path": "src/physics/impact/collision map.js",
               "name": "collision map.js",
               "size": 2003,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\impact\\dynamic bitmaptext body.js",
+              "path": "src/physics/impact/dynamic bitmaptext body.js",
               "name": "dynamic bitmaptext body.js",
               "size": 2400,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\impact\\dynamic graphics body.js",
+              "path": "src/physics/impact/dynamic graphics body.js",
               "name": "dynamic graphics body.js",
               "size": 1874,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\impact\\graphics body.js",
+              "path": "src/physics/impact/graphics body.js",
               "name": "graphics body.js",
               "size": 2302,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\impact\\group shift position from body.js",
+              "path": "src/physics/impact/group shift position from body.js",
               "name": "group shift position from body.js",
               "size": 1365,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\impact\\move body with cursors.js",
+              "path": "src/physics/impact/move body with cursors.js",
               "name": "move body with cursors.js",
               "size": 2702,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\impact\\multiple scenes.js",
+              "path": "src/physics/impact/multiple scenes.js",
               "name": "multiple scenes.js",
               "size": 4791,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\impact\\scaled bodies.js",
+              "path": "src/physics/impact/scaled bodies.js",
               "name": "scaled bodies.js",
               "size": 1301,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\impact\\scaling body.js",
+              "path": "src/physics/impact/scaling body.js",
               "name": "scaling body.js",
               "size": 1338,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\impact\\scene config.js",
+              "path": "src/physics/impact/scene config.js",
               "name": "scene config.js",
               "size": 2048,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\impact\\show debug graphic.js",
+              "path": "src/physics/impact/show debug graphic.js",
               "name": "show debug graphic.js",
               "size": 1237,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\impact\\simple body.js",
+              "path": "src/physics/impact/simple body.js",
               "name": "simple body.js",
               "size": 451,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\impact\\simple floor.js",
+              "path": "src/physics/impact/simple floor.js",
               "name": "simple floor.js",
               "size": 1075,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\impact\\slope tests.js",
+              "path": "src/physics/impact/slope tests.js",
               "name": "slope tests.js",
               "size": 2361,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\impact\\small world bounds from config.js",
+              "path": "src/physics/impact/small world bounds from config.js",
               "name": "small world bounds from config.js",
               "size": 1023,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\impact\\text body.js",
+              "path": "src/physics/impact/text body.js",
               "name": "text body.js",
               "size": 898,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\impact\\tilesprite body.js",
+              "path": "src/physics/impact/tilesprite body.js",
               "name": "tilesprite body.js",
               "size": 1586,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\impact\\world bounds from config.js",
+              "path": "src/physics/impact/world bounds from config.js",
               "name": "world bounds from config.js",
               "size": 837,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\impact\\world bounds optional walls.js",
+              "path": "src/physics/impact/world bounds optional walls.js",
               "name": "world bounds optional walls.js",
               "size": 1201,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\impact\\world bounds.js",
+              "path": "src/physics/impact/world bounds.js",
               "name": "world bounds.js",
               "size": 794,
               "extension": ".js"
@@ -10273,335 +10273,335 @@
           "size": 47327
         },
         {
-          "path": "src\\physics\\matterjs",
+          "path": "src/physics/matterjs",
           "name": "matterjs",
           "children": [
             {
-              "path": "src\\physics\\matterjs\\100 world bodies.js",
+              "path": "src/physics/matterjs/100 world bodies.js",
               "name": "100 world bodies.js",
               "size": 2906,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\add body to bitmap text.js",
+              "path": "src/physics/matterjs/add body to bitmap text.js",
               "name": "add body to bitmap text.js",
               "size": 979,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\add body to text.js",
+              "path": "src/physics/matterjs/add body to text.js",
               "name": "add body to text.js",
               "size": 1088,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\add body to tilesprite.js",
+              "path": "src/physics/matterjs/add body to tilesprite.js",
               "name": "add body to tilesprite.js",
               "size": 1399,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\add body to world.js",
+              "path": "src/physics/matterjs/add body to world.js",
               "name": "add body to world.js",
               "size": 1861,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\advanced shape creation.js",
+              "path": "src/physics/matterjs/advanced shape creation.js",
               "name": "advanced shape creation.js",
               "size": 1785,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\attractors.js",
+              "path": "src/physics/matterjs/attractors.js",
               "name": "attractors.js",
               "size": 1523,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\balls.js",
+              "path": "src/physics/matterjs/balls.js",
               "name": "balls.js",
               "size": 867,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\basic constraint.js",
+              "path": "src/physics/matterjs/basic constraint.js",
               "name": "basic constraint.js",
               "size": 1694,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\body scale.js",
+              "path": "src/physics/matterjs/body scale.js",
               "name": "body scale.js",
               "size": 960,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\body to json.js",
+              "path": "src/physics/matterjs/body to json.js",
               "name": "body to json.js",
               "size": 802,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\body velocity.js",
+              "path": "src/physics/matterjs/body velocity.js",
               "name": "body velocity.js",
               "size": 1107,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\bridge.js",
+              "path": "src/physics/matterjs/bridge.js",
               "name": "bridge.js",
               "size": 1845,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\chain.js",
+              "path": "src/physics/matterjs/chain.js",
               "name": "chain.js",
               "size": 1539,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\chamfer body.js",
+              "path": "src/physics/matterjs/chamfer body.js",
               "name": "chamfer body.js",
               "size": 1347,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\circle body.js",
+              "path": "src/physics/matterjs/circle body.js",
               "name": "circle body.js",
               "size": 900,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\circle stack.js",
+              "path": "src/physics/matterjs/circle stack.js",
               "name": "circle stack.js",
               "size": 2367,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\circular body.js",
+              "path": "src/physics/matterjs/circular body.js",
               "name": "circular body.js",
               "size": 1035,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\cloth.js",
+              "path": "src/physics/matterjs/cloth.js",
               "name": "cloth.js",
               "size": 2122,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\collision event.js",
+              "path": "src/physics/matterjs/collision event.js",
               "name": "collision event.js",
               "size": 914,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\collision filter.js",
+              "path": "src/physics/matterjs/collision filter.js",
               "name": "collision filter.js",
               "size": 1380,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\compound body from physics editor.js",
+              "path": "src/physics/matterjs/compound body from physics editor.js",
               "name": "compound body from physics editor.js",
               "size": 3825,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\compound body.js",
+              "path": "src/physics/matterjs/compound body.js",
               "name": "compound body.js",
               "size": 1386,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\compound sensors.js",
+              "path": "src/physics/matterjs/compound sensors.js",
               "name": "compound sensors.js",
               "size": 3882,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\destroy body.js",
+              "path": "src/physics/matterjs/destroy body.js",
               "name": "destroy body.js",
               "size": 843,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\drag filter with pointer.js",
+              "path": "src/physics/matterjs/drag filter with pointer.js",
               "name": "drag filter with pointer.js",
               "size": 1563,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\drag through balls.js",
+              "path": "src/physics/matterjs/drag through balls.js",
               "name": "drag through balls.js",
               "size": 1116,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\drag with pointer.js",
+              "path": "src/physics/matterjs/drag with pointer.js",
               "name": "drag with pointer.js",
               "size": 728,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\draw chain.js",
+              "path": "src/physics/matterjs/draw chain.js",
               "name": "draw chain.js",
               "size": 1905,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\draw smoother stiff line.js",
+              "path": "src/physics/matterjs/draw smoother stiff line.js",
               "name": "draw smoother stiff line.js",
               "size": 3093,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\draw stiff line.js",
+              "path": "src/physics/matterjs/draw stiff line.js",
               "name": "draw stiff line.js",
               "size": 2399,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\draw triangles.js",
+              "path": "src/physics/matterjs/draw triangles.js",
               "name": "draw triangles.js",
               "size": 1356,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\fixed rotation.js",
+              "path": "src/physics/matterjs/fixed rotation.js",
               "name": "fixed rotation.js",
               "size": 981,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\get shape bounds.js",
+              "path": "src/physics/matterjs/get shape bounds.js",
               "name": "get shape bounds.js",
               "size": 1942,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\ignore gravity.js",
+              "path": "src/physics/matterjs/ignore gravity.js",
               "name": "ignore gravity.js",
               "size": 945,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\increase body scale.js",
+              "path": "src/physics/matterjs/increase body scale.js",
               "name": "increase body scale.js",
               "size": 1092,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\mixed bodies.js",
+              "path": "src/physics/matterjs/mixed bodies.js",
               "name": "mixed bodies.js",
               "size": 1237,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\move body with cursors.js",
+              "path": "src/physics/matterjs/move body with cursors.js",
               "name": "move body with cursors.js",
               "size": 1340,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\multiple physics scenes.js",
+              "path": "src/physics/matterjs/multiple physics scenes.js",
               "name": "multiple physics scenes.js",
               "size": 1913,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\no gravity.js",
+              "path": "src/physics/matterjs/no gravity.js",
               "name": "no gravity.js",
               "size": 648,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\offset body.js",
+              "path": "src/physics/matterjs/offset body.js",
               "name": "offset body.js",
               "size": 1061,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\polygon body.js",
+              "path": "src/physics/matterjs/polygon body.js",
               "name": "polygon body.js",
               "size": 870,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\rectangle body.js",
+              "path": "src/physics/matterjs/rectangle body.js",
               "name": "rectangle body.js",
               "size": 1038,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\restart physics scene.js",
+              "path": "src/physics/matterjs/restart physics scene.js",
               "name": "restart physics scene.js",
               "size": 4109,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\rotate body with cursors.js",
+              "path": "src/physics/matterjs/rotate body with cursors.js",
               "name": "rotate body with cursors.js",
               "size": 1111,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\scene restart.js",
+              "path": "src/physics/matterjs/scene restart.js",
               "name": "scene restart.js",
               "size": 1319,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\scene transition.js",
+              "path": "src/physics/matterjs/scene transition.js",
               "name": "scene transition.js",
               "size": 1979,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\simple body.js",
+              "path": "src/physics/matterjs/simple body.js",
               "name": "simple body.js",
               "size": 736,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\sleep events.js",
+              "path": "src/physics/matterjs/sleep events.js",
               "name": "sleep events.js",
               "size": 1221,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\thrust.js",
+              "path": "src/physics/matterjs/thrust.js",
               "name": "thrust.js",
               "size": 1199,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\top down car body.js",
+              "path": "src/physics/matterjs/top down car body.js",
               "name": "top down car body.js",
               "size": 2161,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\trapezoid body.js",
+              "path": "src/physics/matterjs/trapezoid body.js",
               "name": "trapezoid body.js",
               "size": 895,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\vertices body.js",
+              "path": "src/physics/matterjs/vertices body.js",
               "name": "vertices body.js",
               "size": 1603,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\wrap plugin.js",
+              "path": "src/physics/matterjs/wrap plugin.js",
               "name": "wrap plugin.js",
               "size": 1564,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\matterjs\\wrecking ball.js",
+              "path": "src/physics/matterjs/wrecking ball.js",
               "name": "wrecking ball.js",
               "size": 846,
               "extension": ".js"
@@ -10610,17 +10610,17 @@
           "size": 84326
         },
         {
-          "path": "src\\physics\\multi",
+          "path": "src/physics/multi",
           "name": "multi",
           "children": [
             {
-              "path": "src\\physics\\multi\\arcade and matter and impact.js",
+              "path": "src/physics/multi/arcade and matter and impact.js",
               "name": "arcade and matter and impact.js",
               "size": 1614,
               "extension": ".js"
             },
             {
-              "path": "src\\physics\\multi\\arcade and matter.js",
+              "path": "src/physics/multi/arcade and matter.js",
               "name": "arcade and matter.js",
               "size": 1136,
               "extension": ".js"
@@ -10632,107 +10632,107 @@
       "size": 348359
     },
     {
-      "path": "src\\plugins",
+      "path": "src/plugins",
       "name": "plugins",
       "children": [
         {
-          "path": "src\\plugins\\add global plugin.js",
+          "path": "src/plugins/add global plugin.js",
           "name": "add global plugin.js",
           "size": 2098,
           "extension": ".js"
         },
         {
-          "path": "src\\plugins\\add scene plugin in config.js",
+          "path": "src/plugins/add scene plugin in config.js",
           "name": "add scene plugin in config.js",
           "size": 1012,
           "extension": ".js"
         },
         {
-          "path": "src\\plugins\\custom file type.js",
+          "path": "src/plugins/custom file type.js",
           "name": "custom file type.js",
           "size": 4218,
           "extension": ".js"
         },
         {
-          "path": "src\\plugins\\custom game object.js",
+          "path": "src/plugins/custom game object.js",
           "name": "custom game object.js",
           "size": 1134,
           "extension": ".js"
         },
         {
-          "path": "src\\plugins\\destroy game with plugin.js",
+          "path": "src/plugins/destroy game with plugin.js",
           "name": "destroy game with plugin.js",
           "size": 913,
           "extension": ".js"
         },
         {
-          "path": "src\\plugins\\global plugin test 1.js",
+          "path": "src/plugins/global plugin test 1.js",
           "name": "global plugin test 1.js",
           "size": 1365,
           "extension": ".js"
         },
         {
-          "path": "src\\plugins\\global scene plugin.js",
+          "path": "src/plugins/global scene plugin.js",
           "name": "global scene plugin.js",
           "size": 711,
           "extension": ".js"
         },
         {
-          "path": "src\\plugins\\install global plugin at runtime.js",
+          "path": "src/plugins/install global plugin at runtime.js",
           "name": "install global plugin at runtime.js",
           "size": 1989,
           "extension": ".js"
         },
         {
-          "path": "src\\plugins\\load plugin test 1.js",
+          "path": "src/plugins/load plugin test 1.js",
           "name": "load plugin test 1.js",
           "size": 548,
           "extension": ".js"
         },
         {
-          "path": "src\\plugins\\load plugin test 2.js",
+          "path": "src/plugins/load plugin test 2.js",
           "name": "load plugin test 2.js",
           "size": 1369,
           "extension": ".js"
         },
         {
-          "path": "src\\plugins\\load scene plugin test 1.js",
+          "path": "src/plugins/load scene plugin test 1.js",
           "name": "load scene plugin test 1.js",
           "size": 1058,
           "extension": ".js"
         },
         {
-          "path": "src\\plugins\\load scene plugin test 2.js",
+          "path": "src/plugins/load scene plugin test 2.js",
           "name": "load scene plugin test 2.js",
           "size": 922,
           "extension": ".js"
         },
         {
-          "path": "src\\plugins\\multiple global plugin instances.js",
+          "path": "src/plugins/multiple global plugin instances.js",
           "name": "multiple global plugin instances.js",
           "size": 2005,
           "extension": ".js"
         },
         {
-          "path": "src\\plugins\\scene plugin test 1.js",
+          "path": "src/plugins/scene plugin test 1.js",
           "name": "scene plugin test 1.js",
           "size": 1537,
           "extension": ".js"
         },
         {
-          "path": "src\\plugins\\scene plugin test 2.js",
+          "path": "src/plugins/scene plugin test 2.js",
           "name": "scene plugin test 2.js",
           "size": 2310,
           "extension": ".js"
         },
         {
-          "path": "src\\plugins\\scene plugin test 3.js",
+          "path": "src/plugins/scene plugin test 3.js",
           "name": "scene plugin test 3.js",
           "size": 3425,
           "extension": ".js"
         },
         {
-          "path": "src\\plugins\\start and stop a plugin.js",
+          "path": "src/plugins/start and stop a plugin.js",
           "name": "start and stop a plugin.js",
           "size": 1776,
           "extension": ".js"
@@ -10741,41 +10741,41 @@
       "size": 28390
     },
     {
-      "path": "src\\pools",
+      "path": "src/pools",
       "name": "pools",
       "children": [
         {
-          "path": "src\\pools\\bullets.js",
+          "path": "src/pools/bullets.js",
           "name": "bullets.js",
           "size": 1981,
           "extension": ".js"
         },
         {
-          "path": "src\\pools\\create pool.js",
+          "path": "src/pools/create pool.js",
           "name": "create pool.js",
           "size": 1057,
           "extension": ".js"
         },
         {
-          "path": "src\\pools\\max size.js",
+          "path": "src/pools/max size.js",
           "name": "max size.js",
           "size": 1985,
           "extension": ".js"
         },
         {
-          "path": "src\\pools\\multi pools.js",
+          "path": "src/pools/multi pools.js",
           "name": "multi pools.js",
           "size": 2774,
           "extension": ".js"
         },
         {
-          "path": "src\\pools\\pool using a custom class.js",
+          "path": "src/pools/pool using a custom class.js",
           "name": "pool using a custom class.js",
           "size": 2515,
           "extension": ".js"
         },
         {
-          "path": "src\\pools\\seeded pool.js",
+          "path": "src/pools/seeded pool.js",
           "name": "seeded pool.js",
           "size": 2223,
           "extension": ".js"
@@ -10784,17 +10784,17 @@
       "size": 12535
     },
     {
-      "path": "src\\renderer",
+      "path": "src/renderer",
       "name": "renderer",
       "children": [
         {
-          "path": "src\\renderer\\Custom Pipeline.js",
+          "path": "src/renderer/Custom Pipeline.js",
           "name": "Custom Pipeline.js",
           "size": 2990,
           "extension": ".js"
         },
         {
-          "path": "src\\renderer\\max texture size.js",
+          "path": "src/renderer/max texture size.js",
           "name": "max texture size.js",
           "size": 616,
           "extension": ".js"
@@ -10803,137 +10803,137 @@
       "size": 3606
     },
     {
-      "path": "src\\scalemanager",
+      "path": "src/scalemanager",
       "name": "scalemanager",
       "children": [
         {
-          "path": "src\\scalemanager\\envelop min max.js",
+          "path": "src/scalemanager/envelop min max.js",
           "name": "envelop min max.js",
           "size": 643,
           "extension": ".js"
         },
         {
-          "path": "src\\scalemanager\\envelop.js",
+          "path": "src/scalemanager/envelop.js",
           "name": "envelop.js",
           "size": 486,
           "extension": ".js"
         },
         {
-          "path": "src\\scalemanager\\fit hi-res.js",
+          "path": "src/scalemanager/fit hi-res.js",
           "name": "fit hi-res.js",
           "size": 675,
           "extension": ".js"
         },
         {
-          "path": "src\\scalemanager\\fit min max.js",
+          "path": "src/scalemanager/fit min max.js",
           "name": "fit min max.js",
           "size": 671,
           "extension": ".js"
         },
         {
-          "path": "src\\scalemanager\\fit running game.js",
+          "path": "src/scalemanager/fit running game.js",
           "name": "fit running game.js",
           "size": 3795,
           "extension": ".js"
         },
         {
-          "path": "src\\scalemanager\\fit with auto center.js",
+          "path": "src/scalemanager/fit with auto center.js",
           "name": "fit with auto center.js",
           "size": 528,
           "extension": ".js"
         },
         {
-          "path": "src\\scalemanager\\fit.js",
+          "path": "src/scalemanager/fit.js",
           "name": "fit.js",
           "size": 481,
           "extension": ".js"
         },
         {
-          "path": "src\\scalemanager\\full screen game.js",
+          "path": "src/scalemanager/full screen game.js",
           "name": "full screen game.js",
           "size": 4818,
           "extension": ".js"
         },
         {
-          "path": "src\\scalemanager\\height controls width.js",
+          "path": "src/scalemanager/height controls width.js",
           "name": "height controls width.js",
           "size": 499,
           "extension": ".js"
         },
         {
-          "path": "src\\scalemanager\\manually resize with zoom.js",
+          "path": "src/scalemanager/manually resize with zoom.js",
           "name": "manually resize with zoom.js",
           "size": 1395,
           "extension": ".js"
         },
         {
-          "path": "src\\scalemanager\\manually resize.js",
+          "path": "src/scalemanager/manually resize.js",
           "name": "manually resize.js",
           "size": 1459,
           "extension": ".js"
         },
         {
-          "path": "src\\scalemanager\\no scale with auto center.js",
+          "path": "src/scalemanager/no scale with auto center.js",
           "name": "no scale with auto center.js",
           "size": 530,
           "extension": ".js"
         },
         {
-          "path": "src\\scalemanager\\no scale.js",
+          "path": "src/scalemanager/no scale.js",
           "name": "no scale.js",
           "size": 482,
           "extension": ".js"
         },
         {
-          "path": "src\\scalemanager\\orientation check.js",
+          "path": "src/scalemanager/orientation check.js",
           "name": "orientation check.js",
           "size": 1096,
           "extension": ".js"
         },
         {
-          "path": "src\\scalemanager\\resize min max.js",
+          "path": "src/scalemanager/resize min max.js",
           "name": "resize min max.js",
           "size": 1179,
           "extension": ".js"
         },
         {
-          "path": "src\\scalemanager\\resize on click.js",
+          "path": "src/scalemanager/resize on click.js",
           "name": "resize on click.js",
           "size": 2528,
           "extension": ".js"
         },
         {
-          "path": "src\\scalemanager\\resize.js",
+          "path": "src/scalemanager/resize.js",
           "name": "resize.js",
           "size": 1021,
           "extension": ".js"
         },
         {
-          "path": "src\\scalemanager\\width controls height.js",
+          "path": "src/scalemanager/width controls height.js",
           "name": "width controls height.js",
           "size": 500,
           "extension": ".js"
         },
         {
-          "path": "src\\scalemanager\\world input.js",
+          "path": "src/scalemanager/world input.js",
           "name": "world input.js",
           "size": 3172,
           "extension": ".js"
         },
         {
-          "path": "src\\scalemanager\\zoom manual resize.js",
+          "path": "src/scalemanager/zoom manual resize.js",
           "name": "zoom manual resize.js",
           "size": 766,
           "extension": ".js"
         },
         {
-          "path": "src\\scalemanager\\zoom with fit.js",
+          "path": "src/scalemanager/zoom with fit.js",
           "name": "zoom with fit.js",
           "size": 502,
           "extension": ".js"
         },
         {
-          "path": "src\\scalemanager\\zoom with no scale.js",
+          "path": "src/scalemanager/zoom with no scale.js",
           "name": "zoom with no scale.js",
           "size": 503,
           "extension": ".js"
@@ -10942,123 +10942,123 @@
       "size": 27729
     },
     {
-      "path": "src\\scenes",
+      "path": "src/scenes",
       "name": "scenes",
       "children": [
         {
-          "path": "src\\scenes\\add plugin at runtime.js",
+          "path": "src/scenes/add plugin at runtime.js",
           "name": "add plugin at runtime.js",
           "size": 644,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\add scene after game.js",
+          "path": "src/scenes/add scene after game.js",
           "name": "add scene after game.js",
           "size": 513,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\add scene from another scene.js",
+          "path": "src/scenes/add scene from another scene.js",
           "name": "add scene from another scene.js",
           "size": 701,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\boot data.js",
+          "path": "src/scenes/boot data.js",
           "name": "boot data.js",
           "size": 559,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\bring to top.js",
+          "path": "src/scenes/bring to top.js",
           "name": "bring to top.js",
           "size": 1485,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\call function in another scene es6.js",
+          "path": "src/scenes/call function in another scene es6.js",
           "name": "call function in another scene es6.js",
           "size": 1128,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\call function in another scene.js",
+          "path": "src/scenes/call function in another scene.js",
           "name": "call function in another scene.js",
           "size": 1622,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\change scene from create es6.js",
+          "path": "src/scenes/change scene from create es6.js",
           "name": "change scene from create es6.js",
           "size": 1215,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\change scene from create.js",
+          "path": "src/scenes/change scene from create.js",
           "name": "change scene from create.js",
           "size": 2033,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\change scene from objects.js",
+          "path": "src/scenes/change scene from objects.js",
           "name": "change scene from objects.js",
           "size": 1365,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\changing large scene.js",
+          "path": "src/scenes/changing large scene.js",
           "name": "changing large scene.js",
           "size": 2000,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\changing scene es6.js",
+          "path": "src/scenes/changing scene es6.js",
           "name": "changing scene es6.js",
           "size": 1633,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\changing scene.js",
+          "path": "src/scenes/changing scene.js",
           "name": "changing scene.js",
           "size": 2042,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\copies of the same scene.js",
+          "path": "src/scenes/copies of the same scene.js",
           "name": "copies of the same scene.js",
           "size": 1142,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\cross scene",
+          "path": "src/scenes/cross scene",
           "name": "cross scene",
           "children": [
             {
-              "path": "src\\scenes\\cross scene\\boot.json",
+              "path": "src/scenes/cross scene/boot.json",
               "name": "boot.json",
               "size": 115,
               "extension": ".json"
             },
             {
-              "path": "src\\scenes\\cross scene\\Game.js",
+              "path": "src/scenes/cross scene/Game.js",
               "name": "Game.js",
               "size": 220,
               "extension": ".js"
             },
             {
-              "path": "src\\scenes\\cross scene\\main.js",
+              "path": "src/scenes/cross scene/main.js",
               "name": "main.js",
               "size": 191,
               "extension": ".js"
             },
             {
-              "path": "src\\scenes\\cross scene\\MainMenu.js",
+              "path": "src/scenes/cross scene/MainMenu.js",
               "name": "MainMenu.js",
               "size": 230,
               "extension": ".js"
             },
             {
-              "path": "src\\scenes\\cross scene\\Preloader.js",
+              "path": "src/scenes/cross scene/Preloader.js",
               "name": "Preloader.js",
               "size": 276,
               "extension": ".js"
@@ -11067,35 +11067,35 @@
           "size": 1032
         },
         {
-          "path": "src\\scenes\\drag scenes demo.js",
+          "path": "src/scenes/drag scenes demo.js",
           "name": "drag scenes demo.js",
           "size": 21685,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\extend scene from object.js",
+          "path": "src/scenes/extend scene from object.js",
           "name": "extend scene from object.js",
           "size": 996,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\external scene",
+          "path": "src/scenes/external scene",
           "name": "external scene",
           "children": [
             {
-              "path": "src\\scenes\\external scene\\boot.json",
+              "path": "src/scenes/external scene/boot.json",
               "name": "boot.json",
               "size": 52,
               "extension": ".json"
             },
             {
-              "path": "src\\scenes\\external scene\\Controller.js",
+              "path": "src/scenes/external scene/Controller.js",
               "name": "Controller.js",
               "size": 753,
               "extension": ".js"
             },
             {
-              "path": "src\\scenes\\external scene\\Demo.js",
+              "path": "src/scenes/external scene/Demo.js",
               "name": "Demo.js",
               "size": 501,
               "extension": ".js"
@@ -11104,83 +11104,83 @@
           "size": 1306
         },
         {
-          "path": "src\\scenes\\launch parallel scene.js",
+          "path": "src/scenes/launch parallel scene.js",
           "name": "launch parallel scene.js",
           "size": 1842,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\load external plugin.js",
+          "path": "src/scenes/load external plugin.js",
           "name": "load external plugin.js",
           "size": 516,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\move down list.js",
+          "path": "src/scenes/move down list.js",
           "name": "move down list.js",
           "size": 1480,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\move up list.js",
+          "path": "src/scenes/move up list.js",
           "name": "move up list.js",
           "size": 1478,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\moving scenes demo",
+          "path": "src/scenes/moving scenes demo",
           "name": "moving scenes demo",
           "children": [
             {
-              "path": "src\\scenes\\moving scenes demo\\boot.json",
+              "path": "src/scenes/moving scenes demo/boot.json",
               "name": "boot.json",
               "size": 204,
               "extension": ".json"
             },
             {
-              "path": "src\\scenes\\moving scenes demo\\Controller.js",
+              "path": "src/scenes/moving scenes demo/Controller.js",
               "name": "Controller.js",
               "size": 9372,
               "extension": ".js"
             },
             {
-              "path": "src\\scenes\\moving scenes demo\\main.js",
+              "path": "src/scenes/moving scenes demo/main.js",
               "name": "main.js",
               "size": 258,
               "extension": ".js"
             },
             {
-              "path": "src\\scenes\\moving scenes demo\\SceneA.js",
+              "path": "src/scenes/moving scenes demo/SceneA.js",
               "name": "SceneA.js",
               "size": 380,
               "extension": ".js"
             },
             {
-              "path": "src\\scenes\\moving scenes demo\\SceneB.js",
+              "path": "src/scenes/moving scenes demo/SceneB.js",
               "name": "SceneB.js",
               "size": 498,
               "extension": ".js"
             },
             {
-              "path": "src\\scenes\\moving scenes demo\\SceneC.js",
+              "path": "src/scenes/moving scenes demo/SceneC.js",
               "name": "SceneC.js",
               "size": 1425,
               "extension": ".js"
             },
             {
-              "path": "src\\scenes\\moving scenes demo\\SceneD.js",
+              "path": "src/scenes/moving scenes demo/SceneD.js",
               "name": "SceneD.js",
               "size": 465,
               "extension": ".js"
             },
             {
-              "path": "src\\scenes\\moving scenes demo\\SceneE.js",
+              "path": "src/scenes/moving scenes demo/SceneE.js",
               "name": "SceneE.js",
               "size": 1689,
               "extension": ".js"
             },
             {
-              "path": "src\\scenes\\moving scenes demo\\SceneF.js",
+              "path": "src/scenes/moving scenes demo/SceneF.js",
               "name": "SceneF.js",
               "size": 928,
               "extension": ".js"
@@ -11189,59 +11189,59 @@
           "size": 15219
         },
         {
-          "path": "src\\scenes\\multi demo",
+          "path": "src/scenes/multi demo",
           "name": "multi demo",
           "children": [
             {
-              "path": "src\\scenes\\multi demo\\Boing.js",
+              "path": "src/scenes/multi demo/Boing.js",
               "name": "Boing.js",
               "size": 1142,
               "extension": ".js"
             },
             {
-              "path": "src\\scenes\\multi demo\\boot.json",
+              "path": "src/scenes/multi demo/boot.json",
               "name": "boot.json",
               "size": 202,
               "extension": ".json"
             },
             {
-              "path": "src\\scenes\\multi demo\\Clock.js",
+              "path": "src/scenes/multi demo/Clock.js",
               "name": "Clock.js",
               "size": 3974,
               "extension": ".js"
             },
             {
-              "path": "src\\scenes\\multi demo\\Controller.js",
+              "path": "src/scenes/multi demo/Controller.js",
               "name": "Controller.js",
               "size": 7550,
               "extension": ".js"
             },
             {
-              "path": "src\\scenes\\multi demo\\Eyes.js",
+              "path": "src/scenes/multi demo/Eyes.js",
               "name": "Eyes.js",
               "size": 2416,
               "extension": ".js"
             },
             {
-              "path": "src\\scenes\\multi demo\\Invaders.js",
+              "path": "src/scenes/multi demo/Invaders.js",
               "name": "Invaders.js",
               "size": 6263,
               "extension": ".js"
             },
             {
-              "path": "src\\scenes\\multi demo\\Juggler.js",
+              "path": "src/scenes/multi demo/Juggler.js",
               "name": "Juggler.js",
               "size": 616,
               "extension": ".js"
             },
             {
-              "path": "src\\scenes\\multi demo\\main.js",
+              "path": "src/scenes/multi demo/main.js",
               "name": "main.js",
               "size": 504,
               "extension": ".js"
             },
             {
-              "path": "src\\scenes\\multi demo\\Stars.js",
+              "path": "src/scenes/multi demo/Stars.js",
               "name": "Stars.js",
               "size": 2211,
               "extension": ".js"
@@ -11250,173 +11250,173 @@
           "size": 24878
         },
         {
-          "path": "src\\scenes\\multiple scenes from classes.js",
+          "path": "src/scenes/multiple scenes from classes.js",
           "name": "multiple scenes from classes.js",
           "size": 1137,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\multiple scenes from instances.js",
+          "path": "src/scenes/multiple scenes from instances.js",
           "name": "multiple scenes from instances.js",
           "size": 783,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\multiple scenes from objects.js",
+          "path": "src/scenes/multiple scenes from objects.js",
           "name": "multiple scenes from objects.js",
           "size": 1493,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\multiple scenes with multiple cameras.js",
+          "path": "src/scenes/multiple scenes with multiple cameras.js",
           "name": "multiple scenes with multiple cameras.js",
           "size": 1440,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\parallel scenes.js",
+          "path": "src/scenes/parallel scenes.js",
           "name": "parallel scenes.js",
           "size": 1284,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\passing data to a scene.js",
+          "path": "src/scenes/passing data to a scene.js",
           "name": "passing data to a scene.js",
           "size": 2053,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\pause and resume.js",
+          "path": "src/scenes/pause and resume.js",
           "name": "pause and resume.js",
           "size": 1604,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\registry data exchange es6.js",
+          "path": "src/scenes/registry data exchange es6.js",
           "name": "registry data exchange es6.js",
           "size": 2594,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\registry data exchange.js",
+          "path": "src/scenes/registry data exchange.js",
           "name": "registry data exchange.js",
           "size": 1431,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\restart a scene.js",
+          "path": "src/scenes/restart a scene.js",
           "name": "restart a scene.js",
           "size": 1225,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\scene add manual start.js",
+          "path": "src/scenes/scene add manual start.js",
           "name": "scene add manual start.js",
           "size": 585,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\scene add.js",
+          "path": "src/scenes/scene add.js",
           "name": "scene add.js",
           "size": 562,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\scene config object.js",
+          "path": "src/scenes/scene config object.js",
           "name": "scene config object.js",
           "size": 589,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\scene files payload.js",
+          "path": "src/scenes/scene files payload.js",
           "name": "scene files payload.js",
           "size": 988,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\scene from class.js",
+          "path": "src/scenes/scene from class.js",
           "name": "scene from class.js",
           "size": 584,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\scene from es6 class.js",
+          "path": "src/scenes/scene from es6 class.js",
           "name": "scene from es6 class.js",
           "size": 493,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\scene from function.js",
+          "path": "src/scenes/scene from function.js",
           "name": "scene from function.js",
           "size": 541,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\scene from instance.js",
+          "path": "src/scenes/scene from instance.js",
           "name": "scene from instance.js",
           "size": 375,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\scene from object.js",
+          "path": "src/scenes/scene from object.js",
           "name": "scene from object.js",
           "size": 378,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\scene injection map utf8.js",
+          "path": "src/scenes/scene injection map utf8.js",
           "name": "scene injection map utf8.js",
           "size": 668,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\scene injection map.js",
+          "path": "src/scenes/scene injection map.js",
           "name": "scene injection map.js",
           "size": 965,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\send to back.js",
+          "path": "src/scenes/send to back.js",
           "name": "send to back.js",
           "size": 1485,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\sleep and wake.js",
+          "path": "src/scenes/sleep and wake.js",
           "name": "sleep and wake.js",
           "size": 4316,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\sub game demo",
+          "path": "src/scenes/sub game demo",
           "name": "sub game demo",
           "children": [
             {
-              "path": "src\\scenes\\sub game demo\\boot.json",
+              "path": "src/scenes/sub game demo/boot.json",
               "name": "boot.json",
               "size": 118,
               "extension": ".json"
             },
             {
-              "path": "src\\scenes\\sub game demo\\main.js",
+              "path": "src/scenes/sub game demo/main.js",
               "name": "main.js",
               "size": 334,
               "extension": ".js"
             },
             {
-              "path": "src\\scenes\\sub game demo\\Preloader.js",
+              "path": "src/scenes/sub game demo/Preloader.js",
               "name": "Preloader.js",
               "size": 542,
               "extension": ".js"
             },
             {
-              "path": "src\\scenes\\sub game demo\\SubGame.js",
+              "path": "src/scenes/sub game demo/SubGame.js",
               "name": "SubGame.js",
               "size": 757,
               "extension": ".js"
             },
             {
-              "path": "src\\scenes\\sub game demo\\WorldMap.js",
+              "path": "src/scenes/sub game demo/WorldMap.js",
               "name": "WorldMap.js",
               "size": 2606,
               "extension": ".js"
@@ -11425,53 +11425,53 @@
           "size": 4357
         },
         {
-          "path": "src\\scenes\\swap position.js",
+          "path": "src/scenes/swap position.js",
           "name": "swap position.js",
           "size": 1267,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\swapping scenes.js",
+          "path": "src/scenes/swapping scenes.js",
           "name": "swapping scenes.js",
           "size": 1063,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\test plugin.js",
+          "path": "src/scenes/test plugin.js",
           "name": "test plugin.js",
           "size": 515,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\transition test 1.js",
+          "path": "src/scenes/transition test 1.js",
           "name": "transition test 1.js",
           "size": 3088,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\transition test 2.js",
+          "path": "src/scenes/transition test 2.js",
           "name": "transition test 2.js",
           "size": 5252,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\tutorial",
+          "path": "src/scenes/tutorial",
           "name": "tutorial",
           "children": [
             {
-              "path": "src\\scenes\\tutorial\\change scene order.js",
+              "path": "src/scenes/tutorial/change scene order.js",
               "name": "change scene order.js",
               "size": 1508,
               "extension": ".js"
             },
             {
-              "path": "src\\scenes\\tutorial\\scene controller.js",
+              "path": "src/scenes/tutorial/scene controller.js",
               "name": "scene controller.js",
               "size": 15028,
               "extension": ".js"
             },
             {
-              "path": "src\\scenes\\tutorial\\scene order.js",
+              "path": "src/scenes/tutorial/scene order.js",
               "name": "scene order.js",
               "size": 1571,
               "extension": ".js"
@@ -11480,13 +11480,13 @@
           "size": 18107
         },
         {
-          "path": "src\\scenes\\ui scene es6.js",
+          "path": "src/scenes/ui scene es6.js",
           "name": "ui scene es6.js",
           "size": 1696,
           "extension": ".js"
         },
         {
-          "path": "src\\scenes\\ui scene.js",
+          "path": "src/scenes/ui scene.js",
           "name": "ui scene.js",
           "size": 1976,
           "extension": ".js"
@@ -11495,23 +11495,23 @@
       "size": 153408
     },
     {
-      "path": "src\\snapshot",
+      "path": "src/snapshot",
       "name": "snapshot",
       "children": [
         {
-          "path": "src\\snapshot\\snapshot area.js",
+          "path": "src/snapshot/snapshot area.js",
           "name": "snapshot area.js",
           "size": 3009,
           "extension": ".js"
         },
         {
-          "path": "src\\snapshot\\snapshot game.js",
+          "path": "src/snapshot/snapshot game.js",
           "name": "snapshot game.js",
           "size": 2524,
           "extension": ".js"
         },
         {
-          "path": "src\\snapshot\\snapshot pixel.js",
+          "path": "src/snapshot/snapshot pixel.js",
           "name": "snapshot pixel.js",
           "size": 1482,
           "extension": ".js"
@@ -11520,129 +11520,129 @@
       "size": 7015
     },
     {
-      "path": "src\\spine",
+      "path": "src/spine",
       "name": "spine",
       "children": [
         {
-          "path": "src\\spine\\3.8",
+          "path": "src/spine/3.8",
           "name": "3.8",
           "children": [
             {
-              "path": "src\\spine\\3.8\\add hit area.js",
+              "path": "src/spine/3.8/add hit area.js",
               "name": "add hit area.js",
               "size": 1862,
               "extension": ".js"
             },
             {
-              "path": "src\\spine\\3.8\\arcade physics spine body.js",
+              "path": "src/spine/3.8/arcade physics spine body.js",
               "name": "arcade physics spine body.js",
               "size": 1304,
               "extension": ".js"
             },
             {
-              "path": "src\\spine\\3.8\\basic spineboy.js",
+              "path": "src/spine/3.8/basic spineboy.js",
               "name": "basic spineboy.js",
               "size": 789,
               "extension": ".js"
             },
             {
-              "path": "src\\spine\\3.8\\batch test.js",
+              "path": "src/spine/3.8/batch test.js",
               "name": "batch test.js",
               "size": 1717,
               "extension": ".js"
             },
             {
-              "path": "src\\spine\\3.8\\camera pipeline test.js",
+              "path": "src/spine/3.8/camera pipeline test.js",
               "name": "camera pipeline test.js",
               "size": 2631,
               "extension": ".js"
             },
             {
-              "path": "src\\spine\\3.8\\canvas test 1.js",
+              "path": "src/spine/3.8/canvas test 1.js",
               "name": "canvas test 1.js",
               "size": 1704,
               "extension": ".js"
             },
             {
-              "path": "src\\spine\\3.8\\control bones.js",
+              "path": "src/spine/3.8/control bones.js",
               "name": "control bones.js",
               "size": 1821,
               "extension": ".js"
             },
             {
-              "path": "src\\spine\\3.8\\destroy test.js",
+              "path": "src/spine/3.8/destroy test.js",
               "name": "destroy test.js",
               "size": 1129,
               "extension": ".js"
             },
             {
-              "path": "src\\spine\\3.8\\draw debug bounds.js",
+              "path": "src/spine/3.8/draw debug bounds.js",
               "name": "draw debug bounds.js",
               "size": 3403,
               "extension": ".js"
             },
             {
-              "path": "src\\spine\\3.8\\extended class.js",
+              "path": "src/spine/3.8/extended class.js",
               "name": "extended class.js",
               "size": 2060,
               "extension": ".js"
             },
             {
-              "path": "src\\spine\\3.8\\image changes.js",
+              "path": "src/spine/3.8/image changes.js",
               "name": "image changes.js",
               "size": 777,
               "extension": ".js"
             },
             {
-              "path": "src\\spine\\3.8\\owl.js",
+              "path": "src/spine/3.8/owl.js",
               "name": "owl.js",
               "size": 789,
               "extension": ".js"
             },
             {
-              "path": "src\\spine\\3.8\\spine inside container.js",
+              "path": "src/spine/3.8/spine inside container.js",
               "name": "spine inside container.js",
               "size": 1735,
               "extension": ".js"
             },
             {
-              "path": "src\\spine\\3.8\\spine rotation test.js",
+              "path": "src/spine/3.8/spine rotation test.js",
               "name": "spine rotation test.js",
               "size": 6342,
               "extension": ".js"
             },
             {
-              "path": "src\\spine\\3.8\\spine scene test.js",
+              "path": "src/spine/3.8/spine scene test.js",
               "name": "spine scene test.js",
               "size": 1624,
               "extension": ".js"
             },
             {
-              "path": "src\\spine\\3.8\\webgl test 1.js",
+              "path": "src/spine/3.8/webgl test 1.js",
               "name": "webgl test 1.js",
               "size": 1504,
               "extension": ".js"
             },
             {
-              "path": "src\\spine\\3.8\\webgl test 2.js",
+              "path": "src/spine/3.8/webgl test 2.js",
               "name": "webgl test 2.js",
               "size": 1508,
               "extension": ".js"
             },
             {
-              "path": "src\\spine\\3.8\\webgl test 3.js",
+              "path": "src/spine/3.8/webgl test 3.js",
               "name": "webgl test 3.js",
               "size": 1725,
               "extension": ".js"
             },
             {
-              "path": "src\\spine\\3.8\\webgl test 4.js",
+              "path": "src/spine/3.8/webgl test 4.js",
               "name": "webgl test 4.js",
               "size": 1595,
               "extension": ".js"
             },
             {
-              "path": "src\\spine\\3.8\\webgl test 5.js",
+              "path": "src/spine/3.8/webgl test 5.js",
               "name": "webgl test 5.js",
               "size": 2089,
               "extension": ".js"
@@ -11651,103 +11651,103 @@
           "size": 38108
         },
         {
-          "path": "src\\spine\\add hit area.js",
+          "path": "src/spine/add hit area.js",
           "name": "add hit area.js",
           "size": 1854,
           "extension": ".js"
         },
         {
-          "path": "src\\spine\\arcade physics spine body.js",
+          "path": "src/spine/arcade physics spine body.js",
           "name": "arcade physics spine body.js",
           "size": 1291,
           "extension": ".js"
         },
         {
-          "path": "src\\spine\\basic spineboy.js",
+          "path": "src/spine/basic spineboy.js",
           "name": "basic spineboy.js",
           "size": 781,
           "extension": ".js"
         },
         {
-          "path": "src\\spine\\batch test.js",
+          "path": "src/spine/batch test.js",
           "name": "batch test.js",
           "size": 1709,
           "extension": ".js"
         },
         {
-          "path": "src\\spine\\camera pipeline test.js",
+          "path": "src/spine/camera pipeline test.js",
           "name": "camera pipeline test.js",
           "size": 2623,
           "extension": ".js"
         },
         {
-          "path": "src\\spine\\canvas test 1.js",
+          "path": "src/spine/canvas test 1.js",
           "name": "canvas test 1.js",
           "size": 1691,
           "extension": ".js"
         },
         {
-          "path": "src\\spine\\control bones.js",
+          "path": "src/spine/control bones.js",
           "name": "control bones.js",
           "size": 1789,
           "extension": ".js"
         },
         {
-          "path": "src\\spine\\destroy test.js",
+          "path": "src/spine/destroy test.js",
           "name": "destroy test.js",
           "size": 1117,
           "extension": ".js"
         },
         {
-          "path": "src\\spine\\draw debug bounds.js",
+          "path": "src/spine/draw debug bounds.js",
           "name": "draw debug bounds.js",
           "size": 3395,
           "extension": ".js"
         },
         {
-          "path": "src\\spine\\image changes.js",
+          "path": "src/spine/image changes.js",
           "name": "image changes.js",
           "size": 769,
           "extension": ".js"
         },
         {
-          "path": "src\\spine\\spine inside container.js",
+          "path": "src/spine/spine inside container.js",
           "name": "spine inside container.js",
           "size": 1669,
           "extension": ".js"
         },
         {
-          "path": "src\\spine\\spine rotation test.js",
+          "path": "src/spine/spine rotation test.js",
           "name": "spine rotation test.js",
           "size": 6323,
           "extension": ".js"
         },
         {
-          "path": "src\\spine\\webgl test 1.js",
+          "path": "src/spine/webgl test 1.js",
           "name": "webgl test 1.js",
           "size": 1485,
           "extension": ".js"
         },
         {
-          "path": "src\\spine\\webgl test 2.js",
+          "path": "src/spine/webgl test 2.js",
           "name": "webgl test 2.js",
           "size": 1879,
           "extension": ".js"
         },
         {
-          "path": "src\\spine\\webgl test 3.js",
+          "path": "src/spine/webgl test 3.js",
           "name": "webgl test 3.js",
           "size": 1706,
           "extension": ".js"
         },
         {
-          "path": "src\\spine\\webgl test 4.js",
+          "path": "src/spine/webgl test 4.js",
           "name": "webgl test 4.js",
           "size": 1654,
           "extension": ".js"
         },
         {
-          "path": "src\\spine\\webgl test 5.js",
+          "path": "src/spine/webgl test 5.js",
           "name": "webgl test 5.js",
           "size": 2143,
           "extension": ".js"
@@ -11756,209 +11756,209 @@
       "size": 71986
     },
     {
-      "path": "src\\textures",
+      "path": "src/textures",
       "name": "textures",
       "children": [
         {
-          "path": "src\\textures\\batch canvas texture.js",
+          "path": "src/textures/batch canvas texture.js",
           "name": "batch canvas texture.js",
           "size": 2059,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\batch texture.js",
+          "path": "src/textures/batch texture.js",
           "name": "batch texture.js",
           "size": 2004,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\canvas texture composite op.js",
+          "path": "src/textures/canvas texture composite op.js",
           "name": "canvas texture composite op.js",
           "size": 1285,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\canvas texture rotation.js",
+          "path": "src/textures/canvas texture rotation.js",
           "name": "canvas texture rotation.js",
           "size": 925,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\create canvas.js",
+          "path": "src/textures/create canvas.js",
           "name": "create canvas.js",
           "size": 1670,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\crop animated sprite.js",
+          "path": "src/textures/crop animated sprite.js",
           "name": "crop animated sprite.js",
           "size": 1489,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\crop multi frames.js",
+          "path": "src/textures/crop multi frames.js",
           "name": "crop multi frames.js",
           "size": 612,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\crop render texture.js",
+          "path": "src/textures/crop render texture.js",
           "name": "crop render texture.js",
           "size": 1459,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\crop text.js",
+          "path": "src/textures/crop text.js",
           "name": "crop text.js",
           "size": 1481,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\crop texture atlas frame flip.js",
+          "path": "src/textures/crop texture atlas frame flip.js",
           "name": "crop texture atlas frame flip.js",
           "size": 1256,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\crop texture atlas frame trimmed flip.js",
+          "path": "src/textures/crop texture atlas frame trimmed flip.js",
           "name": "crop texture atlas frame trimmed flip.js",
           "size": 1252,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\crop texture atlas frame trimmed.js",
+          "path": "src/textures/crop texture atlas frame trimmed.js",
           "name": "crop texture atlas frame trimmed.js",
           "size": 1222,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\crop texture atlas frame.js",
+          "path": "src/textures/crop texture atlas frame.js",
           "name": "crop texture atlas frame.js",
           "size": 1224,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\crop texture image flip.js",
+          "path": "src/textures/crop texture image flip.js",
           "name": "crop texture image flip.js",
           "size": 1194,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\crop texture image scaled.js",
+          "path": "src/textures/crop texture image scaled.js",
           "name": "crop texture image scaled.js",
           "size": 1241,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\crop texture image.js",
+          "path": "src/textures/crop texture image.js",
           "name": "crop texture image.js",
           "size": 1166,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\crop tilesprite.js",
+          "path": "src/textures/crop tilesprite.js",
           "name": "crop tilesprite.js",
           "size": 1831,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\edit texture hue shift.js",
+          "path": "src/textures/edit texture hue shift.js",
           "name": "edit texture hue shift.js",
           "size": 1535,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\edit texture silhouette.js",
+          "path": "src/textures/edit texture silhouette.js",
           "name": "edit texture silhouette.js",
           "size": 1245,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\frames from single atlas.js",
+          "path": "src/textures/frames from single atlas.js",
           "name": "frames from single atlas.js",
           "size": 497,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\generate more textures.js",
+          "path": "src/textures/generate more textures.js",
           "name": "generate more textures.js",
           "size": 5255,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\generate texture.js",
+          "path": "src/textures/generate texture.js",
           "name": "generate texture.js",
           "size": 1249,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\get pixel dynamic.js",
+          "path": "src/textures/get pixel dynamic.js",
           "name": "get pixel dynamic.js",
           "size": 958,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\get pixel from image.js",
+          "path": "src/textures/get pixel from image.js",
           "name": "get pixel from image.js",
           "size": 924,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\get pixels.js",
+          "path": "src/textures/get pixels.js",
           "name": "get pixels.js",
           "size": 1008,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\multi atlas.js",
+          "path": "src/textures/multi atlas.js",
           "name": "multi atlas.js",
           "size": 973,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\rotated frames from single atlas.js",
+          "path": "src/textures/rotated frames from single atlas.js",
           "name": "rotated frames from single atlas.js",
           "size": 539,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\sprite sheet from atlas.js",
+          "path": "src/textures/sprite sheet from atlas.js",
           "name": "sprite sheet from atlas.js",
           "size": 2907,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\sprite sheet.js",
+          "path": "src/textures/sprite sheet.js",
           "name": "sprite sheet.js",
           "size": 580,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\text texture.js",
+          "path": "src/textures/text texture.js",
           "name": "text texture.js",
           "size": 897,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\texture from base64.js",
+          "path": "src/textures/texture from base64.js",
           "name": "texture from base64.js",
           "size": 4374,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\texture packer atlas.js",
+          "path": "src/textures/texture packer atlas.js",
           "name": "texture packer atlas.js",
           "size": 956,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\trimmed frame from multi atlas.js",
+          "path": "src/textures/trimmed frame from multi atlas.js",
           "name": "trimmed frame from multi atlas.js",
           "size": 432,
           "extension": ".js"
         },
         {
-          "path": "src\\textures\\trimmed frame from single atlas.js",
+          "path": "src/textures/trimmed frame from single atlas.js",
           "name": "trimmed frame from single atlas.js",
           "size": 495,
           "extension": ".js"
@@ -11967,65 +11967,65 @@
       "size": 48194
     },
     {
-      "path": "src\\time",
+      "path": "src/time",
       "name": "time",
       "children": [
         {
-          "path": "src\\time\\clock.js",
+          "path": "src/time/clock.js",
           "name": "clock.js",
           "size": 2570,
           "extension": ".js"
         },
         {
-          "path": "src\\time\\draw clocks.js",
+          "path": "src/time/draw clocks.js",
           "name": "draw clocks.js",
           "size": 1905,
           "extension": ".js"
         },
         {
-          "path": "src\\time\\looped event.js",
+          "path": "src/time/looped event.js",
           "name": "looped event.js",
           "size": 847,
           "extension": ".js"
         },
         {
-          "path": "src\\time\\multiple timers.js",
+          "path": "src/time/multiple timers.js",
           "name": "multiple timers.js",
           "size": 1035,
           "extension": ".js"
         },
         {
-          "path": "src\\time\\pause and resume.js",
+          "path": "src/time/pause and resume.js",
           "name": "pause and resume.js",
           "size": 1190,
           "extension": ".js"
         },
         {
-          "path": "src\\time\\remove timer event.js",
+          "path": "src/time/remove timer event.js",
           "name": "remove timer event.js",
           "size": 943,
           "extension": ".js"
         },
         {
-          "path": "src\\time\\repeat count.js",
+          "path": "src/time/repeat count.js",
           "name": "repeat count.js",
           "size": 922,
           "extension": ".js"
         },
         {
-          "path": "src\\time\\start at.js",
+          "path": "src/time/start at.js",
           "name": "start at.js",
           "size": 1072,
           "extension": ".js"
         },
         {
-          "path": "src\\time\\time scale.js",
+          "path": "src/time/time scale.js",
           "name": "time scale.js",
           "size": 3067,
           "extension": ".js"
         },
         {
-          "path": "src\\time\\timer event.js",
+          "path": "src/time/timer event.js",
           "name": "timer event.js",
           "size": 997,
           "extension": ".js"
@@ -12034,29 +12034,29 @@
       "size": 14548
     },
     {
-      "path": "src\\timestep",
+      "path": "src/timestep",
       "name": "timestep",
       "children": [
         {
-          "path": "src\\timestep\\delta history.js",
+          "path": "src/timestep/delta history.js",
           "name": "delta history.js",
           "size": 1759,
           "extension": ".js"
         },
         {
-          "path": "src\\timestep\\ticker loop.js",
+          "path": "src/timestep/ticker loop.js",
           "name": "ticker loop.js",
           "size": 1068,
           "extension": ".js"
         },
         {
-          "path": "src\\timestep\\variable smooth step.js",
+          "path": "src/timestep/variable smooth step.js",
           "name": "variable smooth step.js",
           "size": 1727,
           "extension": ".js"
         },
         {
-          "path": "src\\timestep\\world time.js",
+          "path": "src/timestep/world time.js",
           "name": "world time.js",
           "size": 408,
           "extension": ".js"
@@ -12065,39 +12065,39 @@
       "size": 4962
     },
     {
-      "path": "src\\transform",
+      "path": "src/transform",
       "name": "transform",
       "children": [
         {
-          "path": "src\\transform\\angle.js",
+          "path": "src/transform/angle.js",
           "name": "angle.js",
           "size": 642,
           "extension": ".js"
         },
         {
-          "path": "src\\transform\\archived",
+          "path": "src/transform/archived",
           "name": "archived",
           "children": [
             {
-              "path": "src\\transform\\archived\\hasPoint.js",
+              "path": "src/transform/archived/hasPoint.js",
               "name": "hasPoint.js",
               "size": 2607,
               "extension": ".js"
             },
             {
-              "path": "src\\transform\\archived\\ik-test.js",
+              "path": "src/transform/archived/ik-test.js",
               "name": "ik-test.js",
               "size": 1214,
               "extension": ".js"
             },
             {
-              "path": "src\\transform\\archived\\position update.js",
+              "path": "src/transform/archived/position update.js",
               "name": "position update.js",
               "size": 905,
               "extension": ".js"
             },
             {
-              "path": "src\\transform\\archived\\scale update.js",
+              "path": "src/transform/archived/scale update.js",
               "name": "scale update.js",
               "size": 1040,
               "extension": ".js"
@@ -12106,73 +12106,73 @@
           "size": 5766
         },
         {
-          "path": "src\\transform\\display size.js",
+          "path": "src/transform/display size.js",
           "name": "display size.js",
           "size": 640,
           "extension": ".js"
         },
         {
-          "path": "src\\transform\\flip x.js",
+          "path": "src/transform/flip x.js",
           "name": "flip x.js",
           "size": 804,
           "extension": ".js"
         },
         {
-          "path": "src\\transform\\flip y.js",
+          "path": "src/transform/flip y.js",
           "name": "flip y.js",
           "size": 804,
           "extension": ".js"
         },
         {
-          "path": "src\\transform\\originX.js",
+          "path": "src/transform/originX.js",
           "name": "originX.js",
           "size": 1449,
           "extension": ".js"
         },
         {
-          "path": "src\\transform\\originXY.js",
+          "path": "src/transform/originXY.js",
           "name": "originXY.js",
           "size": 2045,
           "extension": ".js"
         },
         {
-          "path": "src\\transform\\originY.js",
+          "path": "src/transform/originY.js",
           "name": "originY.js",
           "size": 1447,
           "extension": ".js"
         },
         {
-          "path": "src\\transform\\position.js",
+          "path": "src/transform/position.js",
           "name": "position.js",
           "size": 848,
           "extension": ".js"
         },
         {
-          "path": "src\\transform\\rotation and origin.js",
+          "path": "src/transform/rotation and origin.js",
           "name": "rotation and origin.js",
           "size": 938,
           "extension": ".js"
         },
         {
-          "path": "src\\transform\\rotation.js",
+          "path": "src/transform/rotation.js",
           "name": "rotation.js",
           "size": 686,
           "extension": ".js"
         },
         {
-          "path": "src\\transform\\scaleX.js",
+          "path": "src/transform/scaleX.js",
           "name": "scaleX.js",
           "size": 669,
           "extension": ".js"
         },
         {
-          "path": "src\\transform\\scaleXY.js",
+          "path": "src/transform/scaleXY.js",
           "name": "scaleXY.js",
           "size": 783,
           "extension": ".js"
         },
         {
-          "path": "src\\transform\\scaleY.js",
+          "path": "src/transform/scaleY.js",
           "name": "scaleY.js",
           "size": 689,
           "extension": ".js"
@@ -12181,411 +12181,411 @@
       "size": 18210
     },
     {
-      "path": "src\\tweens",
+      "path": "src/tweens",
       "name": "tweens",
       "children": [
         {
-          "path": "src\\tweens\\callbacks.js",
+          "path": "src/tweens/callbacks.js",
           "name": "callbacks.js",
           "size": 1325,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\checkerboard 2.js",
+          "path": "src/tweens/checkerboard 2.js",
           "name": "checkerboard 2.js",
           "size": 1138,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\checkerboard 3.js",
+          "path": "src/tweens/checkerboard 3.js",
           "name": "checkerboard 3.js",
           "size": 1195,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\checkerboard 4.js",
+          "path": "src/tweens/checkerboard 4.js",
           "name": "checkerboard 4.js",
           "size": 1243,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\checkerboard rotate.js",
+          "path": "src/tweens/checkerboard rotate.js",
           "name": "checkerboard rotate.js",
           "size": 1705,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\checkerboard.js",
+          "path": "src/tweens/checkerboard.js",
           "name": "checkerboard.js",
           "size": 1085,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\complete delay.js",
+          "path": "src/tweens/complete delay.js",
           "name": "complete delay.js",
           "size": 645,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\custom ease.js",
+          "path": "src/tweens/custom ease.js",
           "name": "custom ease.js",
           "size": 704,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\delay.js",
+          "path": "src/tweens/delay.js",
           "name": "delay.js",
           "size": 678,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\destroy a tween.js",
+          "path": "src/tweens/destroy a tween.js",
           "name": "destroy a tween.js",
           "size": 696,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\dynamic end property.js",
+          "path": "src/tweens/dynamic end property.js",
           "name": "dynamic end property.js",
           "size": 1062,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\dynamic properties multiple.js",
+          "path": "src/tweens/dynamic properties multiple.js",
           "name": "dynamic properties multiple.js",
           "size": 1357,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\dynamic properties.js",
+          "path": "src/tweens/dynamic properties.js",
           "name": "dynamic properties.js",
           "size": 917,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\ease equations.js",
+          "path": "src/tweens/ease equations.js",
           "name": "ease equations.js",
           "size": 1801,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\ease params.js",
+          "path": "src/tweens/ease params.js",
           "name": "ease params.js",
           "size": 828,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\elasticity.js",
+          "path": "src/tweens/elasticity.js",
           "name": "elasticity.js",
           "size": 673,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\flipx.js",
+          "path": "src/tweens/flipx.js",
           "name": "flipx.js",
           "size": 886,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\flipy.js",
+          "path": "src/tweens/flipy.js",
           "name": "flipy.js",
           "size": 801,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\from and to.js",
+          "path": "src/tweens/from and to.js",
           "name": "from and to.js",
           "size": 2560,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\global time scale.js",
+          "path": "src/tweens/global time scale.js",
           "name": "global time scale.js",
           "size": 2816,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\immediate stop a tween.js",
+          "path": "src/tweens/immediate stop a tween.js",
           "name": "immediate stop a tween.js",
           "size": 734,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\linear bounce.js",
+          "path": "src/tweens/linear bounce.js",
           "name": "linear bounce.js",
           "size": 712,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\loop delay.js",
+          "path": "src/tweens/loop delay.js",
           "name": "loop delay.js",
           "size": 667,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\loop.js",
+          "path": "src/tweens/loop.js",
           "name": "loop.js",
           "size": 644,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\multiple delayed properties.js",
+          "path": "src/tweens/multiple delayed properties.js",
           "name": "multiple delayed properties.js",
           "size": 874,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\multiple properties yoyo.js",
+          "path": "src/tweens/multiple properties yoyo.js",
           "name": "multiple properties yoyo.js",
           "size": 631,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\multiple properties.js",
+          "path": "src/tweens/multiple properties.js",
           "name": "multiple properties.js",
           "size": 611,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\multiple targets multiple properties.js",
+          "path": "src/tweens/multiple targets multiple properties.js",
           "name": "multiple targets multiple properties.js",
           "size": 801,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\multiple targets.js",
+          "path": "src/tweens/multiple targets.js",
           "name": "multiple targets.js",
           "size": 737,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\number tween with yoyo.js",
+          "path": "src/tweens/number tween with yoyo.js",
           "name": "number tween with yoyo.js",
           "size": 1060,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\number tween.js",
+          "path": "src/tweens/number tween.js",
           "name": "number tween.js",
           "size": 1037,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\on complete callback.js",
+          "path": "src/tweens/on complete callback.js",
           "name": "on complete callback.js",
           "size": 999,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\on start callback.js",
+          "path": "src/tweens/on start callback.js",
           "name": "on start callback.js",
           "size": 1119,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\on yoyo callback.js",
+          "path": "src/tweens/on yoyo callback.js",
           "name": "on yoyo callback.js",
           "size": 4206,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\pause and resume all.js",
+          "path": "src/tweens/pause and resume all.js",
           "name": "pause and resume all.js",
           "size": 2752,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\pause and resume.js",
+          "path": "src/tweens/pause and resume.js",
           "name": "pause and resume.js",
           "size": 1241,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\paused tween.js",
+          "path": "src/tweens/paused tween.js",
           "name": "paused tween.js",
           "size": 754,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\performance test 1.js",
+          "path": "src/tweens/performance test 1.js",
           "name": "performance test 1.js",
           "size": 2150,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\performance test 2.js",
+          "path": "src/tweens/performance test 2.js",
           "name": "performance test 2.js",
           "size": 1228,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\relative value repeating.js",
+          "path": "src/tweens/relative value repeating.js",
           "name": "relative value repeating.js",
           "size": 616,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\relative value.js",
+          "path": "src/tweens/relative value.js",
           "name": "relative value.js",
           "size": 717,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\repeat and hold.js",
+          "path": "src/tweens/repeat and hold.js",
           "name": "repeat and hold.js",
           "size": 656,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\repeat and yoyo.js",
+          "path": "src/tweens/repeat and yoyo.js",
           "name": "repeat and yoyo.js",
           "size": 656,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\repeat delay and hold.js",
+          "path": "src/tweens/repeat delay and hold.js",
           "name": "repeat delay and hold.js",
           "size": 723,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\repeat delay.js",
+          "path": "src/tweens/repeat delay.js",
           "name": "repeat delay.js",
           "size": 702,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\repeat tween.js",
+          "path": "src/tweens/repeat tween.js",
           "name": "repeat tween.js",
           "size": 657,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\restart.js",
+          "path": "src/tweens/restart.js",
           "name": "restart.js",
           "size": 1043,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\seek.js",
+          "path": "src/tweens/seek.js",
           "name": "seek.js",
           "size": 5183,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\shape morph.js",
+          "path": "src/tweens/shape morph.js",
           "name": "shape morph.js",
           "size": 3011,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\single property.js",
+          "path": "src/tweens/single property.js",
           "name": "single property.js",
           "size": 656,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\stagger compare.js",
+          "path": "src/tweens/stagger compare.js",
           "name": "stagger compare.js",
           "size": 3634,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\stagger delay.js",
+          "path": "src/tweens/stagger delay.js",
           "name": "stagger delay.js",
           "size": 889,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\stagger.js",
+          "path": "src/tweens/stagger.js",
           "name": "stagger.js",
           "size": 935,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\star circle.js",
+          "path": "src/tweens/star circle.js",
           "name": "star circle.js",
           "size": 907,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\stepped ease.js",
+          "path": "src/tweens/stepped ease.js",
           "name": "stepped ease.js",
           "size": 823,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\timelines",
+          "path": "src/tweens/timelines",
           "name": "timelines",
           "children": [
             {
-              "path": "src\\tweens\\timelines\\absolute offsets.js",
+              "path": "src/tweens/timelines/absolute offsets.js",
               "name": "absolute offsets.js",
               "size": 887,
               "extension": ".js"
             },
             {
-              "path": "src\\tweens\\timelines\\create timeline.js",
+              "path": "src/tweens/timelines/create timeline.js",
               "name": "create timeline.js",
               "size": 1084,
               "extension": ".js"
             },
             {
-              "path": "src\\tweens\\timelines\\default properties.js",
+              "path": "src/tweens/timelines/default properties.js",
               "name": "default properties.js",
               "size": 836,
               "extension": ".js"
             },
             {
-              "path": "src\\tweens\\timelines\\loop timeline.js",
+              "path": "src/tweens/timelines/loop timeline.js",
               "name": "loop timeline.js",
               "size": 1182,
               "extension": ".js"
             },
             {
-              "path": "src\\tweens\\timelines\\relative offsets 2.js",
+              "path": "src/tweens/timelines/relative offsets 2.js",
               "name": "relative offsets 2.js",
               "size": 1237,
               "extension": ".js"
             },
             {
-              "path": "src\\tweens\\timelines\\relative offsets.js",
+              "path": "src/tweens/timelines/relative offsets.js",
               "name": "relative offsets.js",
               "size": 898,
               "extension": ".js"
             },
             {
-              "path": "src\\tweens\\timelines\\simple timeline 1.js",
+              "path": "src/tweens/timelines/simple timeline 1.js",
               "name": "simple timeline 1.js",
               "size": 1077,
               "extension": ".js"
             },
             {
-              "path": "src\\tweens\\timelines\\simple timeline 6.js",
+              "path": "src/tweens/timelines/simple timeline 6.js",
               "name": "simple timeline 6.js",
               "size": 930,
               "extension": ".js"
             },
             {
-              "path": "src\\tweens\\timelines\\simple timeline 7.js",
+              "path": "src/tweens/timelines/simple timeline 7.js",
               "name": "simple timeline 7.js",
               "size": 1017,
               "extension": ".js"
             },
             {
-              "path": "src\\tweens\\timelines\\simple timeline 8.js",
+              "path": "src/tweens/timelines/simple timeline 8.js",
               "name": "simple timeline 8.js",
               "size": 1038,
               "extension": ".js"
             },
             {
-              "path": "src\\tweens\\timelines\\simple timeline 9.js",
+              "path": "src/tweens/timelines/simple timeline 9.js",
               "name": "simple timeline 9.js",
               "size": 846,
               "extension": ".js"
             },
             {
-              "path": "src\\tweens\\timelines\\total duration.js",
+              "path": "src/tweens/timelines/total duration.js",
               "name": "total duration.js",
               "size": 1042,
               "extension": ".js"
@@ -12594,37 +12594,37 @@
           "size": 12074
         },
         {
-          "path": "src\\tweens\\tint tween.js",
+          "path": "src/tweens/tint tween.js",
           "name": "tint tween.js",
           "size": 2526,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\total duration.js",
+          "path": "src/tweens/total duration.js",
           "name": "total duration.js",
           "size": 2923,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\tween time scale.js",
+          "path": "src/tweens/tween time scale.js",
           "name": "tween time scale.js",
           "size": 1966,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\update to.js",
+          "path": "src/tweens/update to.js",
           "name": "update to.js",
           "size": 1205,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\yoyo delay.js",
+          "path": "src/tweens/yoyo delay.js",
           "name": "yoyo delay.js",
           "size": 669,
           "extension": ".js"
         },
         {
-          "path": "src\\tweens\\yoyo tween.js",
+          "path": "src/tweens/yoyo tween.js",
           "name": "yoyo tween.js",
           "size": 658,
           "extension": ".js"
@@ -12633,63 +12633,63 @@
       "size": 90901
     },
     {
-      "path": "src\\utils",
+      "path": "src/utils",
       "name": "utils",
       "children": [
         {
-          "path": "src\\utils\\array",
+          "path": "src/utils/array",
           "name": "array",
           "children": [
             {
-              "path": "src\\utils\\array\\bring to top.js",
+              "path": "src/utils/array/bring to top.js",
               "name": "bring to top.js",
               "size": 499,
               "extension": ".js"
             },
             {
-              "path": "src\\utils\\array\\range.js",
+              "path": "src/utils/array/range.js",
               "name": "range.js",
               "size": 937,
               "extension": ".js"
             },
             {
-              "path": "src\\utils\\array\\reverse matrix columns.js",
+              "path": "src/utils/array/reverse matrix columns.js",
               "name": "reverse matrix columns.js",
               "size": 883,
               "extension": ".js"
             },
             {
-              "path": "src\\utils\\array\\reverse matrix rows.js",
+              "path": "src/utils/array/reverse matrix rows.js",
               "name": "reverse matrix rows.js",
               "size": 877,
               "extension": ".js"
             },
             {
-              "path": "src\\utils\\array\\rotate matrix 180.js",
+              "path": "src/utils/array/rotate matrix 180.js",
               "name": "rotate matrix 180.js",
               "size": 873,
               "extension": ".js"
             },
             {
-              "path": "src\\utils\\array\\rotate matrix left.js",
+              "path": "src/utils/array/rotate matrix left.js",
               "name": "rotate matrix left.js",
               "size": 875,
               "extension": ".js"
             },
             {
-              "path": "src\\utils\\array\\rotate matrix right.js",
+              "path": "src/utils/array/rotate matrix right.js",
               "name": "rotate matrix right.js",
               "size": 877,
               "extension": ".js"
             },
             {
-              "path": "src\\utils\\array\\rotate matrix.js",
+              "path": "src/utils/array/rotate matrix.js",
               "name": "rotate matrix.js",
               "size": 871,
               "extension": ".js"
             },
             {
-              "path": "src\\utils\\array\\transpose matrix.js",
+              "path": "src/utils/array/transpose matrix.js",
               "name": "transpose matrix.js",
               "size": 881,
               "extension": ".js"
@@ -12698,17 +12698,17 @@
           "size": 7573
         },
         {
-          "path": "src\\utils\\rbush",
+          "path": "src/utils/rbush",
           "name": "rbush",
           "children": [
             {
-              "path": "src\\utils\\rbush\\rbush 1.js",
+              "path": "src/utils/rbush/rbush 1.js",
               "name": "rbush 1.js",
               "size": 1422,
               "extension": ".js"
             },
             {
-              "path": "src\\utils\\rbush\\rbush 2.js",
+              "path": "src/utils/rbush/rbush 2.js",
               "name": "rbush 2.js",
               "size": 1806,
               "extension": ".js"
@@ -12717,59 +12717,59 @@
           "size": 3228
         },
         {
-          "path": "src\\utils\\size",
+          "path": "src/utils/size",
           "name": "size",
           "children": [
             {
-              "path": "src\\utils\\size\\aspect mode envelop.js",
+              "path": "src/utils/size/aspect mode envelop.js",
               "name": "aspect mode envelop.js",
               "size": 1043,
               "extension": ".js"
             },
             {
-              "path": "src\\utils\\size\\aspect mode fit.js",
+              "path": "src/utils/size/aspect mode fit.js",
               "name": "aspect mode fit.js",
               "size": 1039,
               "extension": ".js"
             },
             {
-              "path": "src\\utils\\size\\aspect mode height controls width.js",
+              "path": "src/utils/size/aspect mode height controls width.js",
               "name": "aspect mode height controls width.js",
               "size": 1057,
               "extension": ".js"
             },
             {
-              "path": "src\\utils\\size\\aspect mode none.js",
+              "path": "src/utils/size/aspect mode none.js",
               "name": "aspect mode none.js",
               "size": 1040,
               "extension": ".js"
             },
             {
-              "path": "src\\utils\\size\\aspect mode width controls height.js",
+              "path": "src/utils/size/aspect mode width controls height.js",
               "name": "aspect mode width controls height.js",
               "size": 1057,
               "extension": ".js"
             },
             {
-              "path": "src\\utils\\size\\max size.js",
+              "path": "src/utils/size/max size.js",
               "name": "max size.js",
               "size": 923,
               "extension": ".js"
             },
             {
-              "path": "src\\utils\\size\\min max size.js",
+              "path": "src/utils/size/min max size.js",
               "name": "min max size.js",
               "size": 914,
               "extension": ".js"
             },
             {
-              "path": "src\\utils\\size\\min size.js",
+              "path": "src/utils/size/min size.js",
               "name": "min size.js",
               "size": 1071,
               "extension": ".js"
             },
             {
-              "path": "src\\utils\\size\\snap child.js",
+              "path": "src/utils/size/snap child.js",
               "name": "snap child.js",
               "size": 1065,
               "extension": ".js"
@@ -12778,7 +12778,7 @@
           "size": 9209
         },
         {
-          "path": "src\\utils\\size4.js",
+          "path": "src/utils/size4.js",
           "name": "size4.js",
           "size": 408,
           "extension": ".js"


### PR DESCRIPTION
As example.json contained `\\` instead of `/`, examples with multiple files (e.g. http://labs.phaser.io/index.html?dir=scenes/cross%20scene/&q=) could not be loaded (except locally on Windows).

Nota bene: there are a few examples where the boot.js contains lowercase filename, but the real filename is upper case. These work on Windows too, but fail on labs.phaser.io