### PR TITLE
example repo fails with 404; turn backslash into slashes to fix it

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -206,6 +206,7 @@
     {
         var div = $('<div></div>').addClass('card');
 
+        filepath = filepath.replace(/\\/g, "/");
         var a = $('<a></a>', { href: 'boot.html?src=' + filepath });
 
         const imgPath = filepath


### PR DESCRIPTION
The example repo, when cloned into the server folder of nginx, fails to work via localhost on Ubuntu/Linux.
For instance, going to
http://localhost/phaser3-examples/public/boot.html?src=src\camera\multi%20camera\boot.json
attempts to access http://localhost/phaser3-examples/public/Controller.js?_=1597765543353
instead of http://localhost/phaser3-examples/public/src/camera/multi%20camera/Controller.js?_=1597765624222
resulting in a 404. 

This patch fixes the provided repo when served directly in this way. The code in index.html appears to use slashes.
Tested on Linux/nginx/Firefox via localhost (not tested on Windows).
I do not know what strategy for converting slashes/backslashes is being used.
