### PR TITLE
Improve video example

### DIFF
--- a/public/src/game objects/video/play video.js
+++ b/public/src/game objects/video/play video.js
@@ -22,4 +22,7 @@ function create ()
     var vid = this.add.video(400, 300, 'wormhole');
 
     vid.play(true);
+    
+    // Prevents video freeze when game is out of focus (i.e. user changes tab on the browser)
+    vid.setPaused(false);
 }


### PR DESCRIPTION
Added setPaused instruction. This call is necessary to prevent a video freeze when the game is not in focus.