### PR TITLE
reuse audio context.jp cannot restart game bug

### DIFF
--- a/public/src/audio/Web Audio/reuse audio context.js
+++ b/public/src/audio/Web Audio/reuse audio context.js
@@ -60,7 +60,7 @@ function create ()
             volume: 0.5
         });
 
-        explosion.on('ended', function (sound) {
+        explosion.on('complete', function (sound) {
 
             setTimeout(function () {
 

--- a/public/src/renderer/multi color pipeline.js
+++ b/public/src/renderer/multi color pipeline.js
@@ -23,10 +23,10 @@ export default class Example extends Phaser.Scene
     {
         const multiColorPipeline = this.renderer.pipelines.get('MultiColor');
 
-        this.add.sprite(100, 300, 'pudding').setPipeline(multiColorPipeline, { effect: 0 });
-        this.add.sprite(400, 300, 'crab').setScale(1.5).setPipeline(multiColorPipeline, { effect: 1 });
-        this.fish = this.add.sprite(400, 300, 'fish').setPipeline(multiColorPipeline, { effect: 1 });
-        this.add.sprite(700, 300, 'cake').setPipeline(multiColorPipeline, { effect: 0 });
+        this.add.sprite(100, 300, 'pudding').setPipeline(multiColorPipeline, { effect: 0, gray:0.9 });
+        this.add.sprite(400, 300, 'crab').setScale(1.5).setPipeline(multiColorPipeline, { effect: 1, speed:0.01 });
+        this.fish = this.add.sprite(400, 300, 'fish').setPipeline(multiColorPipeline, { effect: 1, speed:0.01 });
+        this.add.sprite(700, 300, 'cake').setPipeline(multiColorPipeline, { effect: 0, gray:0.9 });
 
         this.input.on('pointermove', pointer => {
 


### PR DESCRIPTION
The example of `reuse audio context.jp` mey have restart Game when explosion sound completed.
However, it doesn't work. (game donot restart)

so i check the sound events document and fix event names.
It works.

Refs:
I checked this document.
https://photonstorm.github.io/phaser3-docs/Phaser.Sound.Events.html#event:COMPLETE__anchor

-- 
I hope this will help.😊