### PR TITLE
reuse audio context.jp cannot restart game

### DIFF
--- a/public/src/audio/Web Audio/reuse audio context.js
+++ b/public/src/audio/Web Audio/reuse audio context.js
@@ -60,7 +60,7 @@ function create ()
             volume: 0.5
         });
 
-        explosion.on('ended', function (sound) {
+        explosion.on('complete', function (sound) {
 
             setTimeout(function () {
 


### PR DESCRIPTION
The example of reuse audio context.jp mey have restart Game when explosion sound completed.
However, it doesn't work. (game donot restart)

so i check the sound events document and fix event names.
It works.

Refs:
I checked this document.
https://photonstorm.github.io/phaser3-docs/Phaser.Sound.Events.html#event:COMPLETE__anchor

--
I hope this will help.😊