### PR TITLE
MultiColorPipeline dosen’t work

### DIFF
--- a/public/src/renderer/multi color pipeline.js
+++ b/public/src/renderer/multi color pipeline.js
@@ -23,10 +23,10 @@ export default class Example extends Phaser.Scene
     {
         const multiColorPipeline = this.renderer.pipelines.get('MultiColor');
 
-        this.add.sprite(100, 300, 'pudding').setPipeline(multiColorPipeline, { effect: 0 });
-        this.add.sprite(400, 300, 'crab').setScale(1.5).setPipeline(multiColorPipeline, { effect: 1 });
-        this.fish = this.add.sprite(400, 300, 'fish').setPipeline(multiColorPipeline, { effect: 1 });
-        this.add.sprite(700, 300, 'cake').setPipeline(multiColorPipeline, { effect: 0 });
+        this.add.sprite(100, 300, 'pudding').setPipeline(multiColorPipeline, { effect: 0, gray:0.9 });
+        this.add.sprite(400, 300, 'crab').setScale(1.5).setPipeline(multiColorPipeline, { effect: 1, speed:0.01 });
+        this.fish = this.add.sprite(400, 300, 'fish').setPipeline(multiColorPipeline, { effect: 1, speed:0.01 });
+        this.add.sprite(700, 300, 'cake').setPipeline(multiColorPipeline, { effect: 0, gray:0.9 });
 
         this.input.on('pointermove', pointer => {
 


### PR DESCRIPTION
The example of `multi color pipeline.js` tests custompipeline.
The custompipeline has 'glayscale pipeline' and 'hue pipeline' ability.
However, it doesn't work. 

I check pipelinecode of `public/assets/pipelines/MultiColor.js`.
so i discovered bug.
This custompipeline needs variables of 'gray' or 'speed'. 
The current code of `multi color pipeline.js` have no these variables.

so i fix code.it works.

--
I hope this will help.😊