### PR TITLE
select shader test.js can't get pipeline

### DIFF
--- a/public/src/camera/select shader test.js
+++ b/public/src/camera/select shader test.js
@@ -14,7 +14,7 @@ export default class Example extends Phaser.Scene
     create()
     {
         this.image = this.add.image(128, 64, 'einstein');
-        const hueRotatePipeline = this.renderer.pipelines.get('HueRotatePostFX');
+        const hueRotatePipeline = this.renderer.pipelines.getPostPipeline('HueRotatePostFX');
 
         let cam = this.cameras.main;
         cam.setSize(256, 128);


### PR DESCRIPTION
This example would get 'HueRotatePostFX' pipline.
This pipeline type is PostPipeline.
so, need to use 'renderer.pipelines.getPostPipeline' method.

I fix it.
it works.

Refs.
https://photonstorm.github.io/phaser3-docs/Phaser.Renderer.WebGL.PipelineManager.html#getPostPipeline__anchor