### PR TITLE
fix GameObject's data and drag events

### DIFF
--- a/public/src/paths/curves/spline curve bounds.js
+++ b/public/src/paths/curves/spline curve bounds.js
@@ -50,31 +50,31 @@ function create ()
 
         var handle = this.add.image(point.x, point.y, 'dragcircle', 0).setInteractive();
 
-        handle.data.set('vector', point);
+        handle.setData('vector', point);
 
         this.input.setDraggable(handle);
     }
 
-    this.input.on('DRAG_START_EVENT', function (event) {
+    this.input.on('dragstart', function (pointer, gameObject) {
 
-        event.gameObject.setFrame(1);
+        gameObject.setFrame(1);
 
     });
 
-    this.input.on('DRAG_EVENT', function (event) {
+    this.input.on('drag', function (pointer, gameObject, dragX, dragY) {
 
-        event.gameObject.x = event.dragX;
-        event.gameObject.y = event.dragY;
+        gameObject.x = dragX;
+        gameObject.y = dragY;
 
-        event.gameObject.data.get('vector').set(event.dragX, event.dragY);
+        gameObject.data.get('vector').set(dragX, dragY);
 
         curve.getBounds(bounds);
 
     });
 
-    this.input.on('DRAG_END_EVENT', function (event) {
+    this.input.on('dragend', function (pointer, gameObject) {
 
-        event.gameObject.setFrame(0);
+        gameObject.setFrame(0);
 
     });
 


### PR DESCRIPTION
'spline curve bounds.js' example is not work.
it have error 'Cannot read property 'set' of null'.

this example alomost sames "drag spline curve.js".
so, i fixed method of setting data for GameObject.
and i fixed drag events.
it works.

ref.
https://photonstorm.github.io/phaser3-docs/Phaser.GameObjects.GameObject.html#setData__anchor