### PR TITLE
fix dragBug

### DIFF
--- a/public/src/paths/curves/rectangle spline intersection.js
+++ b/public/src/paths/curves/rectangle spline intersection.js
@@ -58,10 +58,10 @@ function create ()
     curve.getBounds(pathBounds);
     image.getBounds(spriteBounds);
 
-    this.input.on(Phaser.Input.Events.DRAG, function (event) {
+    this.input.on(Phaser.Input.Events.DRAG, function (event, gameObject, dragX, dragY) {
 
-        event.gameObject.x = event.dragX;
-        event.gameObject.y = event.dragY;
+        gameObject.x = dragX;
+        gameObject.y = dragY;
 
         image.getBounds(spriteBounds);
 


### PR DESCRIPTION
rectangle spline intersection.js' example is not work.
when i drag rectangle, it have error of 'Cannot set property 'x' of undefined'.

i check code. it is 'Phaser.Input.Events.DRAG' callback param bug.
so i fix it referenced by api documents.
it works.

ref.
https://photonstorm.github.io/phaser3-docs/Phaser.Input.Events.html#event:DRAG