### PR TITLE
Updated circle overlap format to ES6

### DIFF
--- a/public/src/game objects/graphics/circle overlap.js
+++ b/public/src/game objects/graphics/circle overlap.js
@@ -1,49 +1,47 @@
-var config = {
-    width: 800,
-    height: 600,
-    type: Phaser.CANVAS,
-    parent: 'phaser-example',
-    scene: {
-        create: create,
-        update: update
+let t = 0;
+let graphics1;
+let graphics2;
+
+class Example extends Phaser.Scene
+{
+    update ()
+    {
+      t += 0.1;
+
+      graphics1.x += Math.sin(t) * 2;
+      graphics1.y += Math.cos(t) * 2;
+
+      graphics2.x += Math.sin(t) * 3;
+      graphics2.y += Math.cos(t) * 3;
     }
+
+    create ()
+    {
+      graphics2 = this.add.graphics({x: -16, y: 0}).lineStyle(28, 0x00ffff, 0.8);
+      graphics1 = this.add.graphics().lineStyle(28, 0x0000ff, 0.8);
+
+      //  Create the circles
+
+      let radius1 = 64;
+      let radius2 = 32;
+
+      for (let i = 0; i < 8; i++)
+      {
+          graphics1.strokeCircle(400, 300, radius1);
+          graphics2.strokeCircle(400, 300, radius2);
+
+          radius1 += 64;
+          radius2 += 64;
+        }
+    }
+}
+
+const config = {
+  width: 800,
+  height: 600,
+  type: Phaser.CANVAS,
+  parent: 'phaser-example',
+  scene: [ Example ]
 };
 
-var game = new Phaser.Game(config);
-
-var t = 0;
-var graphics1;
-var graphics2;
-
-function create ()
-{
-    graphics2 = this.add.graphics({x: -16, y: 0}).lineStyle(28, 0x00ffff, 0.8);
-    graphics1 = this.add.graphics().lineStyle(28, 0x0000ff, 0.8);
-
-    //  Create the circles
-
-    var radius1 = 64;
-    var radius2 = 32;
-
-    for (var i = 0; i < 8; i++)
-    {
-        graphics1.strokeCircle(400, 300, radius1);
-        graphics2.strokeCircle(400, 300, radius2);
-
-        radius1 += 64;
-        radius2 += 64;
-    }
-
-}
-
-function update ()
-{
-    t += 0.1;
-
-    graphics1.x += Math.sin(t) * 2;
-    graphics1.y += Math.cos(t) * 2;
-
-    graphics2.x += Math.sin(t) * 3;
-    graphics2.y += Math.cos(t) * 3;
-
-}
+const game = new Phaser.Game(config);

--- a/public/src/game objects/graphics/circle overlap.js
+++ b/public/src/game objects/graphics/circle overlap.js
@@ -31,21 +31,21 @@ class Example extends Phaser.Scene
 
     update ()
     {
-      this.t += 0.1;
+        this.t += 0.1;
 
-      this.graphics1.x += Math.sin(this.t) * 2;
-      this.graphics1.y += Math.cos(this.t) * 2;
-      this.graphics2.x += Math.sin(this.t) * 3;
-      this.graphics2.y += Math.cos(this.t) * 3;
+        this.graphics1.x += Math.sin(this.t) * 2;
+        this.graphics1.y += Math.cos(this.t) * 2;
+        this.graphics2.x += Math.sin(this.t) * 3;
+        this.graphics2.y += Math.cos(this.t) * 3;
     }
 }
 
 const config = {
-  width: 800,
-  height: 600,
-  type: Phaser.CANVAS,
-  parent: 'phaser-example',
-  scene: [ Example ]
+    width: 800,
+    height: 600,
+    type: Phaser.CANVAS,
+    parent: 'phaser-example',
+    scene: [ Example ]
 };
 
 const game = new Phaser.Game(config);

--- a/public/src/game objects/graphics/circle overlap.js
+++ b/public/src/game objects/graphics/circle overlap.js
@@ -1,38 +1,42 @@
-let t = 0;
-let graphics1;
-let graphics2;
-
 class Example extends Phaser.Scene
 {
-    update ()
+    constructor ()
     {
-      t += 0.1;
+        super ();
+        this.t = 0;
+        this.graphics1 = undefined;
+        this.graphics2 = undefined;
 
-      graphics1.x += Math.sin(t) * 2;
-      graphics1.y += Math.cos(t) * 2;
-
-      graphics2.x += Math.sin(t) * 3;
-      graphics2.y += Math.cos(t) * 3;
     }
 
     create ()
     {
-      graphics2 = this.add.graphics({x: -16, y: 0}).lineStyle(28, 0x00ffff, 0.8);
-      graphics1 = this.add.graphics().lineStyle(28, 0x0000ff, 0.8);
+        this.graphics2 = this.add.graphics({x: -16, y: 0}).lineStyle(28, 0x00ffff, 0.8);
+        this.graphics1 = this.add.graphics().lineStyle(28, 0x0000ff, 0.8);
 
-      //  Create the circles
+        //  Create the circles
 
-      let radius1 = 64;
-      let radius2 = 32;
+        let radius1 = 64;
+        let radius2 = 32;
 
-      for (let i = 0; i < 8; i++)
-      {
-          graphics1.strokeCircle(400, 300, radius1);
-          graphics2.strokeCircle(400, 300, radius2);
+        for (let i = 0; i < 8; i++)
+        {
+            this.graphics1.strokeCircle(400, 300, radius1);
+            this.graphics2.strokeCircle(400, 300, radius2);
 
-          radius1 += 64;
-          radius2 += 64;
+            radius1 += 64;
+            radius2 += 64;
         }
+    }
+
+    update ()
+    {
+      this.t += 0.1;
+
+      this.graphics1.x += Math.sin(this.t) * 2;
+      this.graphics1.y += Math.cos(this.t) * 2;
+      this.graphics2.x += Math.sin(this.t) * 3;
+      this.graphics2.y += Math.cos(this.t) * 3;
     }
 }
 


### PR DESCRIPTION
Updated format to ES6, upon review fixed inconsistent tabbing in academy/public/src/game objects/graphics/circle overlap.js