### PR TITLE
Update custom sprite class ES6 example to use ES6 format

### DIFF
--- a/public/src/game objects/sprites/custom sprite class ES6.js
+++ b/public/src/game objects/sprites/custom sprite class ES6.js
@@ -17,25 +17,26 @@ class Brain extends Phaser.GameObjects.Sprite {
 
 }
 
-var config = {
+class Example extends Phaser.Scene
+{
+    preload ()
+    {
+        this.load.image('brain', 'assets/sprites/brain.png');
+    }
+
+    create ()
+    {
+        this.add.existing(new Brain(this, 264, 250));
+        this.add.existing(new Brain(this, 464, 350));
+        this.add.existing(new Brain(this, 664, 450));
+    }
+
+}
+
+const config = {
     type: Phaser.AUTO,
     parent: 'phaser-example',
-    scene: {
-        preload: preload,
-        create: create
-    }
+    scene: [ Example ]
 };
 
-var game = new Phaser.Game(config);
-
-function preload ()
-{
-    this.load.image('brain', 'assets/sprites/brain.png');
-}
-
-function create ()
-{
-    this.add.existing(new Brain(this, 264, 250));
-    this.add.existing(new Brain(this, 464, 350));
-    this.add.existing(new Brain(this, 664, 450));
-}
+const game = new Phaser.Game(config);


### PR DESCRIPTION
Updates code to use ES6 format, while keeping existing format conventions.
Originally, the Brain class was in ES6 format while the rest of the code was not.

File path: public/src/game objects/sprites/custom sprite class ES6.js