### PR TITLE
Show github source link on examples

### DIFF
--- a/public/css.html
+++ b/public/css.html
@@ -39,6 +39,7 @@
         <a href="https://github.com/photonstorm/phaser3-examples/issues">Open Issue</a>
         <a id="iframelink">iFrame</a>
         <a id="viewlink">View</a>
+        <a id="sourcelink">Source</a>
 
     </div>
 

--- a/public/iframe.html
+++ b/public/iframe.html
@@ -32,6 +32,7 @@
         <a href="https://github.com/photonstorm/phaser3-examples/issues">Open Issue</a>
         <a id="viewlink">&lt;div&gt;</a>
         <a id="csslink">100%</a>
+        <a id="sourcelink">Source</a>
 
     </div>
 

--- a/public/js/labs.js
+++ b/public/js/labs.js
@@ -24,6 +24,7 @@ $(document).ready(function () {
         $('#iframelink').attr('href', 'iframe.html?src=' + filename);
         $('#csslink').attr('href', 'css.html?src=' + filename);
         $('#viewlink').attr('href', 'view.html?src=' + filename);
+        $('#sourcelink').attr('href', 'https://github.com/photonstorm/phaser3-examples/blob/master/public/' + filename.replace('\\', '/'));
         $('#backlink').attr('href', 'index.html?dir=' + backURL);
         $('#mobilelink').attr('href', 'mobile.html?src=' + filename);
 

--- a/public/view.html
+++ b/public/view.html
@@ -32,6 +32,7 @@
         <a id="labslink">Labs</a>
         <a id="mobilelink">Mobile</a>
         <a id="forcemode">Force Canvas</a>
+        <a id="sourcelink">Source</a>
 
     </div>
 


### PR DESCRIPTION
When I look at an example, I don't really want the heavy editor that pops up when I click `Edit`. I just want to see the source code on github which is faster. So I thought this would be a good way to link to the source.