### PR TITLE
fix: SPRITE_ANIMATION_START to ANIMATION_START

### DIFF
--- a/public/src/animation/chained animation.js
+++ b/public/src/animation/chained animation.js
@@ -57,7 +57,7 @@ class Example extends Phaser.Scene
         lancelot.setScale(8);
         lancelot.play('idle');
 
-        lancelot.on(Phaser.Animations.Events.SPRITE_ANIMATION_START, function (anim) {
+        lancelot.on(Phaser.Animations.Events.ANIMATION_START, function (anim) {
 
             text.setText('Playing ' + anim.key);
 


### PR DESCRIPTION
[https://newdocs.phaser.io/docs/3.55.2/Phaser.Animations.Events.ANIMATION_START](https://newdocs.phaser.io/docs/3.55.2/Phaser.Animations.Events.ANIMATION_START)

SPRITE_ANIMATION_START does not exist anymore, it's ANIMATION_START now