### PR TITLE
Fixed 'chain animation' example's animation start event not being heard

### DIFF
--- a/public/src/animation/chained animation.js
+++ b/public/src/animation/chained animation.js
@@ -57,7 +57,7 @@ class Example extends Phaser.Scene
         lancelot.setScale(8);
         lancelot.play('idle');
 
-        lancelot.on(Phaser.Animations.Events.SPRITE_ANIMATION_START, function (anim) {
+        lancelot.on('animationstart', function (anim) {
 
             text.setText('Playing ' + anim.key);
 


### PR DESCRIPTION
The **chain animation** example text has not changing working on the examples page on the main website https://phaser.io/examples/v3/view/animation/chained-animation 

This small change should fix it.