### PR TITLE
fix create-from-array example asset url

### DIFF
--- a/public/src/tilemap/create from array.js
+++ b/public/src/tilemap/create from array.js
@@ -15,7 +15,7 @@ var game = new Phaser.Game(config);
 
 function preload ()
 {
-    this.load.image('mario-tiles', 'assets/tilemaps/tiles/super-mario.png');
+    this.load.image('mario-tiles', 'assets/tilemaps/tiles/super_mario.png');
 }
 
 function create ()


### PR DESCRIPTION
this existing asset path is a 404 (assets/tilemaps/tiles/super-mario.png)

but this one isn't:
https://examples.phaser.io/assets/tilemaps/tiles/super_mario.png