### PR TITLE
Use `npx` for better compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Phaser 3 Examples",
   "main": "index.js",
   "scripts": {
-    "start": "./node_modules/.bin/http-server -s -o",
+    "start": "npx http-server -s -o",
     "update": "node ./build.js",
     "screenshots": "node ./tools/generate-screenshots.js",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
- Start `http-server` with `npx`. (The existing approach doesn't work on Windows)