### PR TITLE
Update key event strings, replace "underscore" replaced with "dash"

### DIFF
--- a/public/src/bugs/4337 drag destroy.js
+++ b/public/src/bugs/4337 drag destroy.js
@@ -46,12 +46,6 @@ function create()
 
     });
 
-    this.input.keyboard.once('keydown_A', function () {
-
-        circ.destroy();
-
-    });
-
     this.input.keyboard.once('keydown-A', function () {
 
         circ.destroy();

--- a/public/src/display/blend modes/blend mode tester.js
+++ b/public/src/display/blend modes/blend mode tester.js
@@ -103,7 +103,7 @@ class Example extends Phaser.Scene
             equationIndex + ' = ' + list2[equationIndex] + ' - ASR'
         ]);
 
-        this.input.keyboard.on('keydown_A', function (event) {
+        this.input.keyboard.on('keydown-A', function (event) {
 
             equationIndex = 0;
             equation = equations[equationIndex];
@@ -121,7 +121,7 @@ class Example extends Phaser.Scene
 
         });
 
-        this.input.keyboard.on('keydown_S', function (event) {
+        this.input.keyboard.on('keydown-S', function (event) {
 
             equationIndex = 1;
             equation = equations[equationIndex];
@@ -139,7 +139,7 @@ class Example extends Phaser.Scene
 
         });
 
-        this.input.keyboard.on('keydown_R', function (event) {
+        this.input.keyboard.on('keydown-R', function (event) {
 
             equationIndex = 2;
             equation = equations[equationIndex];

--- a/public/src/game objects/container/multi camera input test.js
+++ b/public/src/game objects/container/multi camera input test.js
@@ -83,7 +83,7 @@ class Example extends Phaser.Scene
             maxSpeed: 1.0
         });
 
-        this.input.keyboard.on('keydown_SPACE', event =>
+        this.input.keyboard.on('keydown-SPACE', event =>
         {
 
             if (this.current === this.cam1)
@@ -117,14 +117,14 @@ class Example extends Phaser.Scene
 
         }, this);
 
-        this.input.keyboard.on('keydown_Z', event =>
+        this.input.keyboard.on('keydown-Z', event =>
         {
 
             this.controls.camera.rotation += 0.01;
 
         }, this);
 
-        this.input.keyboard.on('keydown_X', event =>
+        this.input.keyboard.on('keydown-X', event =>
         {
 
             this.controls.camera.rotation -= 0.01;

--- a/public/src/game objects/graphics/_wip/single obj viewer.js
+++ b/public/src/game objects/graphics/_wip/single obj viewer.js
@@ -49,32 +49,32 @@ class Example extends Phaser.Scene
 
         console.log(this.model);
 
-        this.input.keyboard.on('keyup_X', () =>
+        this.input.keyboard.on('keyup-X', () =>
         {
             this.direction = 0;
         });
 
-        this.input.keyboard.on('keyup_Y', () =>
+        this.input.keyboard.on('keyup-Y', () =>
         {
             this.direction = 1;
         });
 
-        this.input.keyboard.on('keyup_Z', () =>
+        this.input.keyboard.on('keyup-Z', () =>
         {
             this.direction = 2;
         });
 
-        this.input.keyboard.on('keydown_LEFT', () =>
+        this.input.keyboard.on('keydown-LEFT', () =>
         {
             this.rotateX3D(-0.03490658503988659);
         });
 
-        this.input.keyboard.on('keydown_RIGHT', () =>
+        this.input.keyboard.on('keydown-RIGHT', () =>
         {
             this.rotateX3D(0.03490658503988659);
         });
 
-        this.input.keyboard.on('keydown_UP', () =>
+        this.input.keyboard.on('keydown-UP', () =>
         {
 
             if (this.direction === 0)
@@ -88,7 +88,7 @@ class Example extends Phaser.Scene
 
         });
 
-        this.input.keyboard.on('keydown_DOWN', () =>
+        this.input.keyboard.on('keydown-DOWN', () =>
         {
 
             if (this.direction === 0)

--- a/public/src/game objects/render texture/draw on texture.js
+++ b/public/src/game objects/render texture/draw on texture.js
@@ -17,7 +17,7 @@ class Example extends Phaser.Scene
 
         let i = 0;
 
-        this.input.keyboard.on('keydown_SPACE', () =>
+        this.input.keyboard.on('keydown-SPACE', () =>
         {
 
             rt.clear();

--- a/public/src/game objects/shapes/iso draw.js
+++ b/public/src/game objects/shapes/iso draw.js
@@ -44,13 +44,13 @@ class Example extends Phaser.Scene
 
 
 
-        // this.input.keyboard.on('keydown_C', this.setCircle, this);
-        // this.input.keyboard.on('keydown_R', this.setRectangle, this);
-        // this.input.keyboard.on('keydown_E', this.setEllipse, this);
-        // this.input.keyboard.on('keydown_S', this.setStar, this);
-        // this.input.keyboard.on('keydown_L', this.setLine, this);
-        // this.input.keyboard.on('keydown_DELETE', this.deleteShape, this);
-        // this.input.keyboard.on('keydown_TAB', this.changeShape, this);
+        // this.input.keyboard.on('keydown-C', this.setCircle, this);
+        // this.input.keyboard.on('keydown-R', this.setRectangle, this);
+        // this.input.keyboard.on('keydown-E', this.setEllipse, this);
+        // this.input.keyboard.on('keydown-S', this.setStar, this);
+        // this.input.keyboard.on('keydown-L', this.setLine, this);
+        // this.input.keyboard.on('keydown-DELETE', this.deleteShape, this);
+        // this.input.keyboard.on('keydown-TAB', this.changeShape, this);
 
         this.cursors = this.input.keyboard.createCursorKeys();
 

--- a/public/src/game objects/shapes/stacker es6.js
+++ b/public/src/game objects/shapes/stacker es6.js
@@ -86,7 +86,7 @@ class Instructions extends Phaser.Scene {
 
         this.add.text(20, 450, 'Space Bar or Click to Place a Row', { fontFamily: 'bebas', fontSize: 40, color: '#ffffff' }).setShadow(2, 2, "#333333", 2, false, true);
 
-        this.input.keyboard.once('keydown_SPACE', this.start, this);
+        this.input.keyboard.once('keydown-SPACE', this.start, this);
         this.input.once('pointerdown', this.start, this);
     }
 
@@ -167,7 +167,7 @@ class StackerGame extends Phaser.Scene {
 
         this.timer = this.time.addEvent({ delay: this.speed, callback: this.moveBlocks, callbackScope: this, loop: true });
 
-        this.input.keyboard.on('keydown_SPACE', this.drop, this);
+        this.input.keyboard.on('keydown-SPACE', this.drop, this);
         this.input.on('pointerdown', this.drop, this);
     }
 
@@ -466,7 +466,7 @@ class StackerGame extends Phaser.Scene {
     {
         this.timer.remove(false);
 
-        this.input.keyboard.off('keydown_SPACE', this.drop);
+        this.input.keyboard.off('keydown-SPACE', this.drop);
         this.input.off('pointerdown', this.drop);
 
         this.registry.set('score', this.gridHeight - this.currentY);
@@ -546,7 +546,7 @@ class GameOver extends Phaser.Scene {
 
         this.add.text(400, 500, 'Space or Click to try again', { fontFamily: 'bebas', fontSize: 26, color: '#ffffff' }).setShadow(2, 2, "#333333", 2, false, true).setOrigin(0.5);
 
-        this.input.keyboard.once('keydown_SPACE', this.restart, this);
+        this.input.keyboard.once('keydown-SPACE', this.restart, this);
         this.input.once('pointerdown', this.restart, this);
     }
 

--- a/public/src/game objects/shapes/stacker.js
+++ b/public/src/game objects/shapes/stacker.js
@@ -57,7 +57,7 @@ class Example extends Phaser.Scene
 
         this.timer = this.time.addEvent({ delay: this.speed, callback: this.moveBlocks, callbackScope: this, loop: true });
 
-        this.input.keyboard.on('keydown_SPACE', this.drop, this);
+        this.input.keyboard.on('keydown-SPACE', this.drop, this);
         this.input.on('pointerdown', this.drop, this);
     }
 

--- a/public/src/games/stacker/stacker.js
+++ b/public/src/games/stacker/stacker.js
@@ -86,7 +86,7 @@ class Instructions extends Phaser.Scene {
 
         this.add.text(20, 450, 'Space Bar or Click to Place a Row', { fontFamily: 'bebas', fontSize: 40, color: '#ffffff' }).setShadow(2, 2, "#333333", 2, false, true);
 
-        this.input.keyboard.once('keydown_SPACE', this.start, this);
+        this.input.keyboard.once('keydown-SPACE', this.start, this);
         this.input.once('pointerdown', this.start, this);
     }
 
@@ -167,7 +167,7 @@ class StackerGame extends Phaser.Scene {
 
         this.timer = this.time.addEvent({ delay: this.speed, callback: this.moveBlocks, callbackScope: this, loop: true });
 
-        this.input.keyboard.on('keydown_SPACE', this.drop, this);
+        this.input.keyboard.on('keydown-SPACE', this.drop, this);
         this.input.on('pointerdown', this.drop, this);
     }
 
@@ -466,7 +466,7 @@ class StackerGame extends Phaser.Scene {
     {
         this.timer.remove(false);
 
-        this.input.keyboard.off('keydown_SPACE', this.drop);
+        this.input.keyboard.off('keydown-SPACE', this.drop);
         this.input.off('pointerdown', this.drop);
 
         this.registry.set('score', this.gridHeight - this.currentY);
@@ -546,7 +546,7 @@ class GameOver extends Phaser.Scene {
 
         this.add.text(400, 500, 'Space or Click to try again', { fontFamily: 'bebas', fontSize: 26, color: '#ffffff' }).setShadow(2, 2, "#333333", 2, false, true).setOrigin(0.5);
 
-        this.input.keyboard.once('keydown_SPACE', this.restart, this);
+        this.input.keyboard.once('keydown-SPACE', this.restart, this);
         this.input.once('pointerdown', this.restart, this);
     }
 

--- a/public/src/input/camera/graphics contains.js
+++ b/public/src/input/camera/graphics contains.js
@@ -78,14 +78,14 @@ class Example extends Phaser.Scene
 
         this.controls = (Phaser.Cameras.Controls.Smoothed) ? new Phaser.Cameras.Controls.SmoothedKeyControl(controlConfig) : new Phaser.Cameras.Controls.SmoothedKeyControl(controlConfig);
 
-        this.input.keyboard.on('keydown_Z', function (event)
+        this.input.keyboard.on('keydown-Z', function (event)
         {
 
             this.cameras.main.rotation += 0.01;
 
         }, this);
 
-        this.input.keyboard.on('keydown_X', function (event)
+        this.input.keyboard.on('keydown-X', function (event)
         {
 
             this.cameras.main.rotation -= 0.01;

--- a/public/src/input/camera/multi cam sprite.js
+++ b/public/src/input/camera/multi cam sprite.js
@@ -79,7 +79,7 @@ class Example extends Phaser.Scene
             maxSpeed: 1.0
         });
 
-        this.input.keyboard.on('keydown_SPACE', event =>
+        this.input.keyboard.on('keydown-SPACE', event =>
         {
 
             if (this.current === this.cam1)
@@ -113,14 +113,14 @@ class Example extends Phaser.Scene
 
         }, this);
 
-        this.input.keyboard.on('keydown_Z', event =>
+        this.input.keyboard.on('keydown-Z', event =>
         {
 
             this.controls.camera.rotation += 0.01;
 
         }, this);
 
-        this.input.keyboard.on('keydown_X', event =>
+        this.input.keyboard.on('keydown-X', event =>
         {
 
             this.controls.camera.rotation -= 0.01;

--- a/public/src/input/game object/world game objects.js
+++ b/public/src/input/game object/world game objects.js
@@ -57,14 +57,14 @@ class Example extends Phaser.Scene
         this.text = this.add.text(100, 200, 'x: 0 y: 0', { font: '18px Courier', fill: '#00ff00' }).setScrollFactor(0);
         this.text2 = this.add.text(100, 400, '', { font: '18px Courier', fill: '#00ff00' }).setScrollFactor(0);
 
-        this.input.keyboard.on('keydown_Z', function (event)
+        this.input.keyboard.on('keydown-Z', function (event)
         {
 
             this.cameras.main.setRotation(this.cameras.main.rotation + 0.01);
 
         }, this);
 
-        this.input.keyboard.on('keydown_X', function (event)
+        this.input.keyboard.on('keydown-X', function (event)
         {
 
             this.cameras.main.setRotation(this.cameras.main.rotation - 0.01);

--- a/public/src/input/keyboard/cross scene keys.js
+++ b/public/src/input/keyboard/cross scene keys.js
@@ -68,7 +68,7 @@ class SceneA extends Phaser.Scene {
     {
         let jelly = this.add.image(150, 500, 'jellies', 'WithShadow/Jelly1').setScale(0.5);
         let bubble1 = createSpeechBubble(this, 20, 30, 220, 80, "Scene A\nKey.on").setVisible(false);
-        let bubble2 = createSpeechBubble(this, 20, 160, 220, 80, "Scene A\nkeydown_SPACE").setVisible(false);
+        let bubble2 = createSpeechBubble(this, 20, 160, 220, 80, "Scene A\nkeydown-SPACE").setVisible(false);
         let bubble3 = createSpeechBubble(this, 20, 290, 220, 80, "Scene A\nkeydown").setVisible(false);
 
         let spaceKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
@@ -92,7 +92,7 @@ class SceneA extends Phaser.Scene {
         //  Call stopImmediatePropagation to stop it reaching the global handler in this Scene.
         //  Call stopPropagation to stop it reaching any other Scene.
 
-        this.input.keyboard.on('keydown_SPACE', function (event) {
+        this.input.keyboard.on('keydown-SPACE', function (event) {
 
             // event.stopPropagation();
             // event.stopImmediatePropagation();
@@ -135,7 +135,7 @@ class SceneB extends Phaser.Scene {
     {
         let jelly = this.add.image(400, 500, 'jellies', 'WithShadow/Jelly2').setScale(0.5);
         let bubble1 = createSpeechBubble(this, 290, 30, 220, 80, "Scene B\nKey.on").setVisible(false);
-        let bubble2 = createSpeechBubble(this, 290, 160, 220, 80, "Scene B\nkeydown_SPACE").setVisible(false);
+        let bubble2 = createSpeechBubble(this, 290, 160, 220, 80, "Scene B\nkeydown-SPACE").setVisible(false);
         let bubble3 = createSpeechBubble(this, 290, 290, 220, 80, "Scene B\nkeydown").setVisible(false);
 
         let spaceKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
@@ -159,7 +159,7 @@ class SceneB extends Phaser.Scene {
         //  Call stopImmediatePropagation to stop it reaching the global handler in this Scene.
         //  Call stopPropagation to stop it reaching any other Scene.
 
-        this.input.keyboard.on('keydown_SPACE', function (event) {
+        this.input.keyboard.on('keydown-SPACE', function (event) {
 
             // event.stopPropagation();
             // event.stopImmediatePropagation();
@@ -198,7 +198,7 @@ class SceneC extends Phaser.Scene {
     {
         let jelly = this.add.image(650, 500, 'jellies', 'WithShadow/Jelly3').setScale(0.5);
         let bubble1 = createSpeechBubble(this, 560, 30, 220, 80, "Scene C\nKey.on").setVisible(false);
-        let bubble2 = createSpeechBubble(this, 560, 160, 220, 80, "Scene C\nkeydown_SPACE").setVisible(false);
+        let bubble2 = createSpeechBubble(this, 560, 160, 220, 80, "Scene C\nkeydown-SPACE").setVisible(false);
         let bubble3 = createSpeechBubble(this, 560, 290, 220, 80, "Scene C\nkeydown").setVisible(false);
 
         let spaceKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
@@ -222,7 +222,7 @@ class SceneC extends Phaser.Scene {
         //  Call stopImmediatePropagation to stop it reaching the global handler in this Scene.
         //  Call stopPropagation to stop it reaching any other Scene.
 
-        this.input.keyboard.on('keydown_SPACE', function (event) {
+        this.input.keyboard.on('keydown-SPACE', function (event) {
 
             // event.stopPropagation();
             // event.stopImmediatePropagation();

--- a/public/src/input/keyboard/key modifier.js
+++ b/public/src/input/keyboard/key modifier.js
@@ -2,7 +2,7 @@ class Example extends Phaser.Scene
 {
     create ()
     {
-        this.input.keyboard.on('keydown_A', event =>
+        this.input.keyboard.on('keydown-A', event =>
         {
 
             if (event.ctrlKey)

--- a/public/src/input/keyboard/keydown multi scene test.js
+++ b/public/src/input/keyboard/keydown multi scene test.js
@@ -23,26 +23,26 @@ class SceneA extends Phaser.Scene {
 
         this.input.keyboard.addCapture('UP, DOWN, LEFT, RIGHT')
 
-        this.input.keyboard.on('keydown_UP', function (event) {
+        this.input.keyboard.on('keydown-UP', function (event) {
 
             hotdog.y -= 4;
 
         }, this);
 
-        this.input.keyboard.on('keydown_DOWN', function (event) {
+        this.input.keyboard.on('keydown-DOWN', function (event) {
 
             hotdog.y += 4;
 
         }, this);
 
-        this.input.keyboard.on('keydown_LEFT', function (event) {
+        this.input.keyboard.on('keydown-LEFT', function (event) {
 
             console.log('A left');
             hotdog.x -= 4;
 
         }, this);
 
-        this.input.keyboard.on('keydown_RIGHT', function (event) {
+        this.input.keyboard.on('keydown-RIGHT', function (event) {
 
             console.log('A right');
             hotdog.x += 4;
@@ -89,33 +89,33 @@ class SceneB extends Phaser.Scene {
 
         this.input.keyboard.addCapture('UP, DOWN, LEFT, RIGHT');
 
-        this.input.keyboard.on('keydown_UP', function (event) {
+        this.input.keyboard.on('keydown-UP', function (event) {
 
             hotdog.y -= 4;
 
         }, this);
 
-        this.input.keyboard.on('keydown_DOWN', function (event) {
+        this.input.keyboard.on('keydown-DOWN', function (event) {
 
             hotdog.y += 4;
 
         }, this);
 
-        this.input.keyboard.on('keydown_LEFT', function (event) {
+        this.input.keyboard.on('keydown-LEFT', function (event) {
 
             console.log('B left');
             hotdog.x -= 4;
 
         }, this);
 
-        this.input.keyboard.on('keydown_RIGHT', function (event) {
+        this.input.keyboard.on('keydown-RIGHT', function (event) {
 
             console.log('B right');
             hotdog.x += 4;
 
         }, this);
 
-        this.input.keyboard.once('keydown_SPACE', function (event) {
+        this.input.keyboard.once('keydown-SPACE', function (event) {
 
             this.scene.stop();
             this.scene.resume('sceneA');

--- a/public/src/physics/arcade/topdown shooter average focus.js
+++ b/public/src/physics/arcade/topdown shooter average focus.js
@@ -53,30 +53,30 @@ class Example extends Phaser.Scene
         });
 
         // Enables movement of player with WASD keys
-        this.input.keyboard.on('keydown_W', (event) => {
+        this.input.keyboard.on('keydown-W', (event) => {
             this.player.setAccelerationY(-800);
         });
-        this.input.keyboard.on('keydown_S', (event) => {
+        this.input.keyboard.on('keydown-S', (event) => {
             this.player.setAccelerationY(800);
         });
-        this.input.keyboard.on('keydown_A', (event) => {
+        this.input.keyboard.on('keydown-A', (event) => {
             this.player.setAccelerationX(-800);
         });
-        this.input.keyboard.on('keydown_D', (event) => {
+        this.input.keyboard.on('keydown-D', (event) => {
             this.player.setAccelerationX(800);
         });
 
         // Stops player acceleration on uppress of WASD keys
-        this.input.keyboard.on('keyup_W', (event) => {
+        this.input.keyboard.on('keyup-W', (event) => {
             if (this.moveKeys['down'].isUp) { this.player.setAccelerationY(0); }
         });
-        this.input.keyboard.on('keyup_S', (event) => {
+        this.input.keyboard.on('keyup-S', (event) => {
             if (this.moveKeys['up'].isUp) { this.player.setAccelerationY(0); }
         });
-        this.input.keyboard.on('keyup_A', (event) => {
+        this.input.keyboard.on('keyup-A', (event) => {
             if (this.moveKeys['right'].isUp) { this.player.setAccelerationX(0); }
         });
-        this.input.keyboard.on('keyup_D', (event) => {
+        this.input.keyboard.on('keyup-D', (event) => {
             if (this.moveKeys['left'].isUp) { this.player.setAccelerationX(0); }
         });
 
@@ -87,7 +87,7 @@ class Example extends Phaser.Scene
 
         // Exit pointer lock when Q or escape (by default) is pressed.
         this.input.keyboard.on(
-            'keydown_Q',
+            'keydown-Q',
             (event) =>
             {
                 if (game.input.mouse.locked) { game.input.mouse.releasePointerLock(); }

--- a/public/src/physics/arcade/topdown shooter combat mechanics.js
+++ b/public/src/physics/arcade/topdown shooter combat mechanics.js
@@ -68,30 +68,30 @@ class Example extends Phaser.Scene
         });
 
         // Enables movement of player with WASD keys
-        this.input.keyboard.on('keydown_W', event => {
+        this.input.keyboard.on('keydown-W', event => {
             this.player.setAccelerationY(-800);
         });
-        this.input.keyboard.on('keydown_S', event => {
+        this.input.keyboard.on('keydown-S', event => {
             this.player.setAccelerationY(800);
         });
-        this.input.keyboard.on('keydown_A', event => {
+        this.input.keyboard.on('keydown-A', event => {
             this.player.setAccelerationX(-800);
         });
-        this.input.keyboard.on('keydown_D', event => {
+        this.input.keyboard.on('keydown-D', event => {
             this.player.setAccelerationX(800);
         });
 
         // Stops player acceleration on uppress of WASD keys
-        this.input.keyboard.on('keyup_W', event => {
+        this.input.keyboard.on('keyup-W', event => {
             if (this.moveKeys['down'].isUp) { this.player.setAccelerationY(0); }
         });
-        this.input.keyboard.on('keyup_S', event => {
+        this.input.keyboard.on('keyup-S', event => {
             if (this.moveKeys['up'].isUp) { this.player.setAccelerationY(0); }
         });
-        this.input.keyboard.on('keyup_A', event => {
+        this.input.keyboard.on('keyup-A', event => {
             if (this.moveKeys['right'].isUp) { this.player.setAccelerationX(0); }
         });
-        this.input.keyboard.on('keyup_D', event => {
+        this.input.keyboard.on('keyup-D', event => {
             if (this.moveKeys['left'].isUp) { this.player.setAccelerationX(0); }
         });
 
@@ -116,7 +116,7 @@ class Example extends Phaser.Scene
         });
 
         // Exit pointer lock when Q or escape (by default) is pressed.
-        this.input.keyboard.on('keydown_Q', event => {
+        this.input.keyboard.on('keydown-Q', event => {
             if (game.input.mouse.locked) { game.input.mouse.releasePointerLock(); }
         }, 0);
 

--- a/public/src/physics/arcade/topdown shooter player focus.js
+++ b/public/src/physics/arcade/topdown shooter player focus.js
@@ -44,30 +44,30 @@ class Example extends Phaser.Scene
         });
 
         // Enables movement of player with WASD keys
-        this.input.keyboard.on('keydown_W', event => {
+        this.input.keyboard.on('keydown-W', event => {
             this.player.setAccelerationY(-800);
         });
-        this.input.keyboard.on('keydown_S', event => {
+        this.input.keyboard.on('keydown-S', event => {
             this.player.setAccelerationY(800);
         });
-        this.input.keyboard.on('keydown_A', event => {
+        this.input.keyboard.on('keydown-A', event => {
             this.player.setAccelerationX(-800);
         });
-        this.input.keyboard.on('keydown_D', event => {
+        this.input.keyboard.on('keydown-D', event => {
             this.player.setAccelerationX(800);
         });
 
         // Stops player acceleration on uppress of WASD keys
-        this.input.keyboard.on('keyup_W', event => {
+        this.input.keyboard.on('keyup-W', event => {
             if (this.moveKeys['down'].isUp) { this.player.setAccelerationY(0); }
         });
-        this.input.keyboard.on('keyup_S', event => {
+        this.input.keyboard.on('keyup-S', event => {
             if (this.moveKeys['up'].isUp) { this.player.setAccelerationY(0); }
         });
-        this.input.keyboard.on('keyup_A', event => {
+        this.input.keyboard.on('keyup-A', event => {
             if (this.moveKeys['right'].isUp) { this.player.setAccelerationX(0); }
         });
-        this.input.keyboard.on('keyup_D', event => {
+        this.input.keyboard.on('keyup-D', event => {
             if (this.moveKeys['left'].isUp) { this.player.setAccelerationX(0); }
         });
 
@@ -77,7 +77,7 @@ class Example extends Phaser.Scene
         });
 
         // Exit pointer lock when Q or escape (by default) is pressed.
-        this.input.keyboard.on('keydown_Q', event => {
+        this.input.keyboard.on('keydown-Q', event => {
             if (game.input.mouse.locked) { game.input.mouse.releasePointerLock(); }
         }, 0, this);
 

--- a/public/src/physics/arcade/topdown shooter target focus.js
+++ b/public/src/physics/arcade/topdown shooter target focus.js
@@ -44,30 +44,30 @@ class Example extends Phaser.Scene
         });
 
         // Enables movement of player with WASD keys
-        this.input.keyboard.on('keydown_W', event => {
+        this.input.keyboard.on('keydown-W', event => {
             this.player.setAccelerationY(-800);
         });
-        this.input.keyboard.on('keydown_S', event => {
+        this.input.keyboard.on('keydown-S', event => {
             this.player.setAccelerationY(800);
         });
-        this.input.keyboard.on('keydown_A', event => {
+        this.input.keyboard.on('keydown-A', event => {
             this.player.setAccelerationX(-800);
         });
-        this.input.keyboard.on('keydown_D', event => {
+        this.input.keyboard.on('keydown-D', event => {
             this.player.setAccelerationX(800);
         });
 
         // Stops player acceleration on uppress of WASD keys
-        this.input.keyboard.on('keyup_W', event => {
+        this.input.keyboard.on('keyup-W', event => {
             if (this.moveKeys['down'].isUp) { this.player.setAccelerationY(0); }
         });
-        this.input.keyboard.on('keyup_S', event => {
+        this.input.keyboard.on('keyup-S', event => {
             if (this.moveKeys['up'].isUp) { this.player.setAccelerationY(0); }
         });
-        this.input.keyboard.on('keyup_A', event => {
+        this.input.keyboard.on('keyup-A', event => {
             if (this.moveKeys['right'].isUp) { this.player.setAccelerationX(0); }
         });
-        this.input.keyboard.on('keyup_D', event => {
+        this.input.keyboard.on('keyup-D', event => {
             if (this.moveKeys['left'].isUp) { this.player.setAccelerationX(0); }
         });
 
@@ -77,7 +77,7 @@ class Example extends Phaser.Scene
         });
 
         // Exit pointer lock when Q or escape (by default) is pressed.
-        this.input.keyboard.on('keydown_Q', event => {
+        this.input.keyboard.on('keydown-Q', event => {
             if (game.input.mouse.locked) { game.input.mouse.releasePointerLock(); }
         }, 0, this);
 

--- a/public/src/tilemap/tests/visual tile coords test.js
+++ b/public/src/tilemap/tests/visual tile coords test.js
@@ -37,22 +37,22 @@ class Example extends Phaser.Scene
 
         this.selectLayer(this.tileLayer);
 
-        this.input.keyboard.on('keydown_ONE', event =>
+        this.input.keyboard.on('keydown-ONE', event =>
         {
             this.selectLayer(this.tileLayer);
         });
 
-        this.input.keyboard.on('keydown_TWO', event =>
+        this.input.keyboard.on('keydown-TWO', event =>
         {
             this.selectLayer(this.offsetTileLayer);
         });
 
-        this.input.keyboard.on('keydown_THREE', event =>
+        this.input.keyboard.on('keydown-THREE', event =>
         {
             this.selectLayer(this.tileLayer2);
         });
 
-        this.input.keyboard.on('keydown_FOUR', event =>
+        this.input.keyboard.on('keydown-FOUR', event =>
         {
             this.selectLayer(this.smallTileLayer);
         });


### PR DESCRIPTION
This pull request only fixes the keycode strings, replacing "underscores" with a "dash".
Hope this helps, I stubbled on a few of these, when I was using the examples.