### PR TITLE
removed the path on "npm start" for win users

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Phaser 3 Examples",
   "main": "index.js",
   "scripts": {
-    "start": "./node_modules/.bin/http-server -s -o",
+    "start": "http-server -s -o",
     "update": "node ./build.js",
     "update355": "node ./build355.js",
     "update324": "node ./build324.js",


### PR DESCRIPTION
removed the path on "npm start" so that Windows powershell will not have issues with the .bin/ folder.

npm should identify the package and it's path automatically when invoked without the path.