### PR TITLE
incresed the iterator in the loop so that all the images could be load

### DIFF
--- a/public/src/actions/align to base.js
+++ b/public/src/actions/align to base.js
@@ -32,7 +32,7 @@ class Example extends Phaser.Scene
 
         const sprites = [];
 
-        for (let i = 1; i < 15; i++)
+        for (let i = 1; i < 16; i++)
         {
             sprites.push(this.add.sprite(150, 493, `image${i}`));
         }


### PR DESCRIPTION
I Think, You want to load all of the images in the https://phaser.io/examples/v3/view/actions/align-to-base
align to base file 
for this you need to iterate through all of the images
but with 15 only 14 images are loaded
that's why i fixed it